### PR TITLE
Fix for not being able to disable recurrence of an event

### DIFF
--- a/src/scenes/AddEdit/add-edit-scene.jsx
+++ b/src/scenes/AddEdit/add-edit-scene.jsx
@@ -173,7 +173,7 @@ export default class AddEditEventScene extends React.Component {
      };
 
     recurrenceSelected = () =>{
-      let data = this.state.eventData;
+      let data = Object.assign({}, this.state.eventData);
       if(data.recurrence){
         delete data.recurrence;
       }


### PR DESCRIPTION
Fixed bug where unchecking recurrence checkbox wouldn't remove recurrence data from event. Closes #98.