### PR TITLE
Update README; remove

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+ABE_URL = http://localhost:5000/
+DEBUG = true

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,7 @@ ENV/
 /site
 
 # End of https://www.gitignore.io/api/linux,django,node,python,pycharm
+
+# `yarn webpack:deploy` creates these
+bundle.js
+bundle.js.map

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # A Web Frontend for ABE
+
 This is a Web front-end for the
 [Olin College of Engineering Library](http://www.olin.build)'s
 [Amorphous Blob of Events](https://github.com/olinlibrary/ABE).
@@ -9,14 +10,14 @@ In order to run ABE's Web frontend, you'll need [Node.js](https://nodejs.org/en/
 [React](https://facebook.github.io/react/), [Babel](https://babeljs.io/) and [Webpack](https://webpack.js.org/).
 You can install them by following the instructions below.
 
-#### Clone This Repo
+### Clone This Repo
 
 You first need to clone the code from this repository to your computer. To do that, run the following:
 
     git clone https://github.com/olinlibrary/abe-web.git
     cd abe-web
 
-#### Node.js
+### Node.js
 
 Then you'll need to install the Node.js server and a package manager (yarn).
 
@@ -32,38 +33,40 @@ On Ubuntu:
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install nodejs yarn
 
-#### Dependencies
+### Dependencies
 
 Once you have Node installed, you can use `yarn` to install the necessary packages (read from `package.json`).
 
     yarn install
 
-#### Environment variables
+### Environment variables
 
 Certain environment variables need to be set before running the server:
 
-  * ABE_URL (required) - to the URL of the ABE backend instance you'd like to connect to (please use a dev instance when developing)
-  * DEBUG (optional) - set to `true` if you'd like to use the Redux devtools
-  * GA_ID (optional) - set to your Google Analytics tracking ID
+* ABE_URL (required) - to the URL of the ABE backend instance you'd like to connect to (please use a dev instance when developing)
+* DEBUG (optional) - set to `true` if you'd like to use the Redux devtools
+* GA_ID (optional) - set to your Google Analytics tracking ID
 
 This can be done through Node environment variables (if you know how), or by creating a text file called `.env` in the root of the repository.
 If you are a member of Hacking the Library, use [this starter .env file](https://docs.google.com/document/d/1CZ45xYT33sTi5xpFJF8BkEeniCRszaxcfwiBmvMdmbk/edit).
 Otherwise, make your own. Its contents should be in the following format:
+
 ```
 ABE_URL = https://my-abe-instance.com/
 DEBUG = true
 ```
 
-#### Build and Run
+## Build and Run
 
 To launch the web app, run the following:
 
     node server.js
 
-Then visit [http://localhost:8080](http://localhost:8080) in your browser.
+Then visit <http://localhost:8080> in your browser.
 
 Changes should be reflected in your browser every time you save a file (except CSS files, which currently require a manual refresh),
 but it may take a couple seconds for Webpack to recompile everything.
 
 ## Supporters
+
 <a target="_blank" href="http://browserstack.com/" alt="BrowserStack"><img align="right" src="https://bstacksupport.zendesk.com/attachments/token/GVENo6DR01sT3B5jsNRfU0II7/?name=Logo-01.svg" width="40%"></a>We'd like to extend a special thank you to [BrowserStack](http://browserstack.com/) for providing us with their testing service free of charge. BrowserStack allows us to test our project in a multitude of browsers on various platforms, including IE, Safari, Android and iOS, to ensure compatibility with as many as possible.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Certain environment variables need to be set before running the server:
 * DEBUG (optional) - set to `true` if you'd like to use the Redux devtools
 * GA_ID (optional) - set to your Google Analytics tracking ID
 
-This can be done through Node environment variables (if you know how), or by creating a text file called `.env` in the root of the repository.
+This can be done through Node environment variables, or by creating a text file
+called `.env` in the root of the repository.
+
+To run against a local instance of ABE that is running on port, copy
+`.env.template` to `.env`.
+
 If you are a member of Hacking the Library, use [this starter .env file](https://docs.google.com/document/d/1CZ45xYT33sTi5xpFJF8BkEeniCRszaxcfwiBmvMdmbk/edit).
 Otherwise, make your own. Its contents should be in the following format:
-
-```
-ABE_URL = https://my-abe-instance.com/
-DEBUG = true
-```
 
 ## Build and Run
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You first need to clone the code from this repository to your computer. To do th
 
 Then you'll need to install the Node.js server and a package manager (yarn).
 
+Install nodejs [from here](https://nodejs.org/en/), and yarn
+[here](https://yarnpkg.com/en/).
+
+On macOS running [Homebrew](https://brew.sh/), you can install both nodejs and
+yarn via `brew install yarn`.
+
+On Ubuntu:
+
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install nodejs yarn

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "abe-web-frontend",
   "version": "1.0.0",
-  "description": "Web frontend utilizing React for Olin College of Engineering's Amorphous Blob of Events (ABE).",
+  "description":
+    "Web frontend utilizing React for Olin College of Engineering's Amorphous Blob of Events (ABE).",
   "main": "app.js",
   "scripts": {
     "webpack:deploy": "webpack --config=webpack.config.js -p",
@@ -11,7 +12,7 @@
     "stats": "webpack --json > stats.json"
   },
   "engines": {
-    "node": "6.11.1"
+    "node": "^9"
   },
   "repository": {
     "type": "git",
@@ -69,7 +70,8 @@
     "serve-static": "^1.12.3",
     "svg-react-loader": "^0.4.4",
     "typescript": "^2.4.1",
-    "ultra-responsive-calendar": "git+https://github.com/kylecombes/ultra-responsive-calendar.git",
+    "ultra-responsive-calendar":
+      "git+https://github.com/kylecombes/ultra-responsive-calendar.git",
     "webpack": "^2.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
README:
* Add brew instructions for macOS
* Default instructions now work with local instance of ABE back end

package.json:
* Upgrade to node 9.x, so that out-of-box instructions work with current node download

.gitignore:
* Add a couple of files created by `yarn webpack:deploy`