### PR TITLE
Fix #106 modify dev build to serve from / instead of /public

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ cd into the abe-web directory first, then run yarn install
     yarn install
 
 ### Environment variables
+
 If you are a member of Hacking the Library, use [this starter .env file](https://docs.google.com/document/d/1CZ45xYT33sTi5xpFJF8BkEeniCRszaxcfwiBmvMdmbk/edit).
 Otherwise, make your own. Its contents should be in the following format:
 
@@ -61,15 +62,14 @@ called `.env` in the root of the repository.
 To run against a local instance of ABE that is running on port, copy
 `.env.template` to `.env`.
 
-
 ## Build and Run
 
 To launch the web app, make sure you have a local ABE instance running
 on port 3000 (go to https://github.com/olinlibrary/ABE for instructions on how to run ABE) and run the following:
 
-    yarn run dev
+    yarn dev
 
-Then visit <http://localhost:8080/public/> in your browser.
+Then visit <http://localhost:8080/> in your browser.
 
 Changes should be reflected in your browser every time you save a file (except CSS files, which currently require a manual refresh),
 but it may take a couple seconds for Webpack to recompile everything.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ var config = {
         ]
     },
     devServer: {
+        contentBase: ['./public', '.'],
         historyApiFallback: true
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,28 +5,28 @@ var BUILD_DIR = path.resolve(__dirname);
 var APP_DIR = path.resolve(__dirname, 'src');
 
 var config = {
-    devtool:'source-map',
+    devtool: 'source-map',
     entry: APP_DIR + '/app.jsx',
     output: {
         path: BUILD_DIR,
         publicPath: '/public/build/',
         filename: 'bundle.js'
     },
-    module : {
-        loaders : [
+    module: {
+        loaders: [
             {
-                test : /\.jsx?/,
-                include : APP_DIR,
-                loader : 'babel-loader'
-            },
+                test: /\.jsx?/,
+                include: APP_DIR,
+                loader: 'babel-loader'
+            }
         ]
     },
     devServer: {
         historyApiFallback: true
     },
     resolve: {
-        extensions: ['.js', '.jsx'],
-    },
-  };
+        extensions: ['.js', '.jsx']
+    }
+};
 
 module.exports = config;


### PR DESCRIPTION
This modifies the webpack devserver config to serve from http://localhost/ instead of http://localhost/public/. This fixes an issue that (despite the README) has been a source of confusion; brings the actual instructions into line with those that webpack prints to the console when it starts; and also fixes the issue that when the app is run from /, the developer must then click on the icon to get to the actual calendar view.