### PR TITLE
Fix #124 Production isn't picking up changes to ABE_URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,6 @@
 </head>
 <body>
 <div id="app"></div>
-<script type="text/javascript">
-    window.abe_url = 'https://abe.olin.build';
-    window.debug = true;
-</script>
 <script src="/public/build/bundle.js" type="text/javascript"></script>
 <link rel="stylesheet" href="/node_modules/input-moment/dist/input-moment.css"/>
 <link rel="stylesheet" type="text/css" href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">

--- a/index.html.js
+++ b/index.html.js
@@ -1,4 +1,4 @@
-const getHTML = (abeUrl, isDev) => {
+const getHTML = () => {
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,17 +8,12 @@ const getHTML = (abeUrl, isDev) => {
 </head>
 <body>
 <div id="app"></div>
-<script type="text/javascript">
-    window.abe_url = "${abeUrl}";
-    window.debug = ${isDev.toString()};
-    window.GA_ID = "${process.env.GA_ID}";
-</script>
 <script src="/public/build/bundle.js" type="text/javascript"></script>
 <link rel="stylesheet" href="/node_modules/input-moment/dist/input-moment.css"/>
 <link rel="stylesheet" type="text/css" href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
 <link rel='stylesheet' href='/public/css/app.css'/>
 </body>
-</html>`
-};
+</html>`;
+}
 
 module.exports = getHTML;

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -16,6 +16,12 @@ import ViewEventContainer from "./containers/view-container";
 import ImportContainer from "./containers/import-container";
 import * as reducers from './data/reducers';
 import SidebarMode from "./data/sidebar-modes";
+
+// Remove trailing slash, if present
+window.abe_url = process.env.ABE_URL.replace(/\/$/, '');
+window.debug = process.env.DEBUG || false;
+window.GA_ID = process.env.GA_ID;
+
 const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
 const initialState = {
     general: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,13 @@ var config = {
             { test: require.resolve('moment'), loader: 'expose-loader?moment' }
         ]
     },
+    plugins: [
+        new webpack.EnvironmentPlugin({
+            ABE_URL: 'http://localhost:5000/',
+            DEBUG: false,
+            GA_ID: null
+        })
+    ],
     devServer: {
         historyApiFallback: true
     }


### PR DESCRIPTION
Use `webpack.EnvironmentPlugin` to expose build-time environment
variables (`ABE_URL`, `DEBUG`, `GA_ID`) as runtime `process.env[*]`.

This is a hotfix to `master`, to work around the outage caused by  olinlibrary/ABE#143. It makes minimal changes. I'm preparing a different PR based on this one, but with additional simplifications, to apply to `dev`. That will also be an increment towards #125.