### PR TITLE
Use webpack environment plugin to access ABE_URL (dev version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ Otherwise, make your own. Its contents should be in the following format:
 
 Certain environment variables need to be set before running the server:
 
-* ABE_URL (required) - to the URL of the ABE backend instance you'd like to connect to (please use a dev instance when developing)
-* DEBUG (optional) - set to `true` if you'd like to use the Redux devtools
+* ABE_URL (optional) - the URL of the ABE back-end instance you'd like to
+   connect to. (Please use a dev instance when developing.) This defaults to
+   <http://localhost:3000/>, which is the URL of a local
+   [ABE](https://github.com/olinlibrary/abe) instance.
+* DEBUG (optional) - set to `true` to use the Redux devtools
 * GA_ID (optional) - set to your Google Analytics tracking ID
 
 This can be done through Node environment variables, or by creating a text file

--- a/index.html.js
+++ b/index.html.js
@@ -1,6 +1,4 @@
-const googleAnalyticsId = process.env.GA_ID ? `window.GA_ID = ${process.env.GA_ID};` : '';
-
-const getHTML = (abeUrl, isDev) => {
+const getHTML = () => {
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,11 +8,6 @@ const getHTML = (abeUrl, isDev) => {
 </head>
 <body>
 <div id="app"></div>
-<script type="text/javascript">
-    window.abe_url = "${abeUrl}";
-    window.debug = ${isDev.toString()};
-    ${googleAnalyticsId}
-</script>
 <script src="/bundle.js" type="text/javascript"></script>
 <link rel="stylesheet" href="/node_modules/input-moment/dist/input-moment.css"/>
 <link rel="stylesheet" type="text/css" href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">

--- a/public/index.html
+++ b/public/index.html
@@ -7,10 +7,6 @@
 </head>
 <body>
 <div id="app"></div>
-<script type="text/javascript">
-  window.abe_url = "http://localhost:3000";
-  window.debug = true;
-</script>
 <script src="/public/build/bundle.js" type="text/javascript"></script>
 <link rel="stylesheet" href="/node_modules/input-moment/dist/input-moment.css"/>
 <link rel="stylesheet" type="text/css" href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">

--- a/server.js
+++ b/server.js
@@ -23,11 +23,6 @@ if (fs.existsSync('./.env')) { // Check if we're running on a local dev machine
 
 }
 
-let abeUrl = process.env.ABE_URL;
-if (!abeUrl) {
-  console.error('Unspecified environment variable "ABE_URL". Please define path to ABE instance.');
-  return;
-}
 const getHtml = require('./index.html.js'); // Ugly HTML template TODO Do this better
 const html = getHtml();
 

--- a/server.js
+++ b/server.js
@@ -28,12 +28,8 @@ if (!abeUrl) {
   console.error('Unspecified environment variable "ABE_URL". Please define path to ABE instance.');
   return;
 }
-if (abeUrl[abeUrl.length-1] === '/') { // Remove trailing slash, if present
-  abeUrl = abeUrl.substring(0, abeUrl.length-1);
-}
-const debugMode = process.env.DEBUG || false;
 const getHtml = require('./index.html.js'); // Ugly HTML template TODO Do this better
-const html = getHtml(abeUrl, debugMode);
+const html = getHtml();
 
 const routes = [
   '/',

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,9 +18,11 @@ import * as reducers from './data/reducers';
 import SidebarMode from "./data/sidebar-modes";
 
 // Remove trailing slash, if present
+// TODO: change this from a global to a provider pattern.
 window.abe_url = process.env.ABE_URL.replace(/\/$/, '');
-window.debug = process.env.DEBUG || false;
-window.GA_ID = process.env.GA_ID;
+
+const DEBUG = process.env.DEBUG || false;
+const GA_ID = process.env.GA_ID;
 
 const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
 const initialState = {
@@ -83,9 +85,9 @@ initialState.calendar.currentViewMode = isMobile
 const history = createHistory();
 
 // Google Analytics
-if (window.GA_ID) {
-    ReactGA.initialize(window.GA_ID, {
-        debug: window.debug
+if (GA_ID) {
+    ReactGA.initialize(GA_ID, {
+        debug: DEBUG
     });
     history.listen((event) => {
         // Dispatch page changes to Google Analytics
@@ -98,7 +100,7 @@ if (window.GA_ID) {
 
 const routeMiddleware = routerMiddleware(history);
 let store;
-if (window.debug && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+if (DEBUG && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
     store = createStore(
         combineReducers({...reducers, router: routerReducer}),

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,6 +17,11 @@ import ImportContainer from "./containers/import-container";
 import * as reducers from './data/reducers';
 import SidebarMode from "./data/sidebar-modes";
 
+// Remove trailing slash, if present
+window.abe_url = process.env.ABE_URL.replace(/\/$/, '');
+window.debug = process.env.DEBUG || false;
+window.GA_ID = process.env.GA_ID;
+
 const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
 const initialState = {
     general: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ var config = {
     },
     plugins: [
         new webpack.EnvironmentPlugin({
-            ABE_URL: 'http://localhost:5000/',
+            ABE_URL: 'http://localhost:3000/',
             DEBUG: false,
             GA_ID: null
         })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,13 @@ var config = {
             }
         ]
     },
+    plugins: [
+        new webpack.EnvironmentPlugin({
+            ABE_URL: 'http://localhost:5000/',
+            DEBUG: false,
+            GA_ID: null
+        })
+    ],
     devServer: {
         contentBase: ['./public', '.'],
         historyApiFallback: true


### PR DESCRIPTION
This is the dev version of the production hotfix PR #126 (that fixes #124). It additional updates the default `ABE_URL` and README such that the app can run against the a local ABE back end with no configuration; and removes the use of `window` as an intermediary for storing `DEBUG` and `GA_ID`.

Future work, that is enabled by these changes but that this PR doesn't implement, is:
* Server a static `index.html`.
* Use a provider pattern to provide the value of `ABE_URL`, instead of storing it on `window`.