### PR TITLE
New creation and editing workflow for subscriptions

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,7 +34,8 @@ const routes = [
   '/import',
   '/edit/:id',
   '/edit/:sid/:rec_id',
-  '/view/:id'
+  '/view/:id',
+  '/subscription/:id'
 ];
 
 app.get(routes, function(req, res) {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,6 +13,7 @@ import SidebarContainer from "./containers/sidebar-container";
 import AddEditContainer from "./containers/add-edit-container";
 import ViewEventContainer from "./containers/event-details-container";
 import ImportContainer from "./containers/import-container";
+import SubscriptionContainer from "./containers/subscription-container";
 
 // Remove trailing slash, if present
 // TODO: change this from a global to a provider pattern.
@@ -51,6 +52,7 @@ class App extends React.Component {
                 <Route exact path='/edit/:id' component={AddEditContainer}/>
                 <Route path='/edit/:sid/:rec_id' component={AddEditContainer}/>
                 <Route path='/view/:id' component={ViewEventContainer}/>
+                <Route path='/subscription/:id' component={SubscriptionContainer}/>
               </Switch>
             </Router>
           </div>

--- a/src/containers/subscription-container.js
+++ b/src/containers/subscription-container.js
@@ -1,0 +1,63 @@
+// This container is a sort of middleware between the React import component and the Redux data store
+
+import { connect } from 'react-redux';
+import {
+  setSidebarMode,
+  toggleSidebarCollapsed,
+  setPageTitlePrefix,
+} from '../data/actions';
+import SubscriptionEditorPage from '../pages/subscription/subscription';
+import * as ga from 'react-ga';
+
+// This function passes values/objects from the Redux state to the React component as props
+const mapStateToProps = state => {
+    return {
+        general: state.general,
+        labels: state.labels.labelList
+    }
+};
+
+// This function passes functions from /srcs/data/actions.jsx to the React component as props
+const mapDispatchToProps = (dispatch, getState) => {
+    return {
+        setSidebarMode: mode => {
+            dispatch(setSidebarMode(mode));
+        },
+        toggleSidebarCollapsed: () => {
+            dispatch(toggleSidebarCollapsed());
+            const action = getState().sidebar.isCollapsed ? 'expanding' : 'collapsing';
+            ga.event({
+                category: 'Sidebar',
+                variable: 'collapseToggle',
+                value: action,
+                label: 'User toggled the visibility of the sidebar',
+            });
+        },
+        setPageTitlePrefix: (title) => {
+            dispatch(setPageTitlePrefix(title));
+        },
+        importSuccess: (response, importData) => {
+            ga.event({
+                category: 'ICS Feed Import',
+                variable: 'success',
+                value: importData,
+                label: 'User successfully imported ICS feed into ABE',
+            });
+            alert('ICS imported successfully');
+        },
+        importFailed: (error, importData) => {
+            ga.event({
+                category: 'ICS Feed Import',
+                variable: 'failure',
+                value: JSON.stringify({ error, importData }),
+                label: 'ICS feed import into ABE failed',
+            });
+            alert('ICS import failed:\n' + error);
+        },
+    };
+};
+
+// Connect props to Redux state and actions
+const SubscriptionContainer = connect(mapStateToProps, mapDispatchToProps)(SubscriptionEditorPage);
+
+export default SubscriptionContainer;

--- a/src/containers/subscription-container.js
+++ b/src/containers/subscription-container.js
@@ -38,21 +38,21 @@ const mapDispatchToProps = (dispatch, getState) => {
         },
         importSuccess: (response, importData) => {
             ga.event({
-                category: 'ICS Feed Import',
+                category: 'Subscription Preferences',
                 variable: 'success',
                 value: importData,
-                label: 'User successfully imported ICS feed into ABE',
+                label: 'User successfully edited their subscription',
             });
-            alert('ICS imported successfully');
+            alert('Subscription preferences edited');
         },
         importFailed: (error, importData) => {
             ga.event({
-                category: 'ICS Feed Import',
+                category: 'Subscription Preferences',
                 variable: 'failure',
                 value: JSON.stringify({ error, importData }),
-                label: 'ICS feed import into ABE failed',
+                label: 'Editing subscription preferences failed',
             });
-            alert('ICS import failed:\n' + error);
+            alert('Subscription editing failed:\n' + error);
         },
     };
 };

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -10,50 +10,62 @@ export default class SubscriptionEditorPage extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            importData: {
+            data: {
                 labels : [],
-                url : '',
+                id : '',
             },
         };
+
+        Object.assign(this.state.data, this.getIdFromURL(props));
+
         this.props.setSidebarMode(SidebarModes.IMPORT);
         props.setPageTitlePrefix('Edit Subscription');
     }
 
+    getIdFromURL = (props) => {
+        if ('match' in props && 'id' in props.match.params) {
+            return {id: props.match.params.id};
+        }
+        return null;
+    };
+
     labelToggled = (labelName) => {
-        let labels = this.state.importData.labels.slice();
+        let labels = this.state.data.labels.slice();
         if (labels.includes(labelName)) {
             labels.splice(labels.indexOf(labelName),1);
         } else {
             labels.push(labelName);
         }
-        this.setState({importData: Object.assign({}, this.state.importData, {labels})});
+        this.setState({data: Object.assign({}, this.state.data, {labels})});
       };
 
-      urlChanged = (e) => {
-          let importData = this.state.importData;
-          importData = Object.assign(importData, {url: e.currentTarget.value});
-          this.setState({importData : importData});
-      };
+      // urlChanged = (e) => {
+      //     let importData = this.state.importData;
+      //     importData = Object.assign(importData, {url: e.currentTarget.value});
+      //     this.setState({importData : importData});
+      // };
 
-    submitICS = () => {
-        axios.post(window.abe_url + '/ics/', this.state.importData)
+    submitSubscription = () => {
+      console.log(this.state);
+      axios.put(window.abe_url + '/subscriptions/'+this.state.data.id, this.state.data)
           .then(
             (response) => this.props.importSuccess(response, this.state.importData),
             (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
           );
     };
 
-      render(){
-        return(
-          <div className="row expanded page-container">
-              <div className="row content-container">
-                  <h1 className="page-title"><MenuIconButton onClick={this.props.toggleSidebarCollapsed} tooltip="Show/Hide Sidebar"/>Import</h1>
-                  <input required="required" type="url" placeholder=".../example_calendar.ics" className="wide-text-box single-line-text-box medium-text-box" onChange={this.urlChanged}/>
-                  <TagPane contentClass='import-filters' {...this.props} possibleLabels={this.props.labels} selectedLabels={this.state.importData.labels} labelToggled={this.labelToggled}/>
-                  <br/>
-                  <input type="submit" className="button submit" value="Submit" onClick={this.submitICS}/>
-              </div>
-          </div>
-        )
-      }
+    render(){
+      return(
+        <div className="row expanded page-container">
+            <div className="row content-container">
+                <h1 className="page-title"><MenuIconButton onClick={this.props.toggleSidebarCollapsed} tooltip="Show/Hide Sidebar"/>Edit Subscription: {this.state.data.id}</h1>
+                {/*<input required="required" type="url" placeholder=".../example_calendar.ics" className="wide-text-box single-line-text-box medium-text-box" onChange={this.urlChanged}/>*/}
+                <h2>Tags: </h2>
+                <TagPane contentClass='import-filters' {...this.props} possibleLabels={this.props.labels} selectedLabels={this.state.data.labels} labelToggled={this.labelToggled}/>
+                <br/>
+                <input type="submit" className="button submit" value="Submit" onClick={this.submitSubscription}/>
+            </div>
+        </div>
+      )
+    }
 }

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -58,7 +58,7 @@ export default class SubscriptionEditorPage extends React.Component {
           .then(
             (response) => {
                   this.setState({data: Object.assign({}, this.state.data, response.data)}); 
-                  window.alert("Subscription preferences saved");
+                  this.props.importSuccess(response, response.data);
                 },
             (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
           );
@@ -67,7 +67,6 @@ export default class SubscriptionEditorPage extends React.Component {
     copyToClipboard() {
         var url = window.abe_url + this.state.data.ics_url
         copy(url);
-        // this.props.icsUrlCopiedToClipboard(url);
         alert("Link copied to clipboard");
     }
 

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import axios from 'axios';
+import copy from 'copy-to-clipboard';
 import SidebarModes from "../../data/sidebar-modes";
 import TagPane from "../../components/label-pane.jsx";
 import MenuIconButton from '../../components/menu-icon-button.jsx';
@@ -25,6 +26,8 @@ export default class SubscriptionEditorPage extends React.Component {
 
         this.props.setSidebarMode(SidebarModes.IMPORT);
         props.setPageTitlePrefix('Edit Subscription');
+
+        this.copyToClipboard = this.copyToClipboard.bind(this);
     }
 
     getIdFromURL = (props) => {
@@ -53,10 +56,20 @@ export default class SubscriptionEditorPage extends React.Component {
     submitSubscription = () => {
       axios.put(window.abe_url + '/subscriptions/'+this.state.data.id, this.state.data)
           .then(
-            (response) => window.alert('Successfully saved subscription preferences'),
+            (response) => {
+                  this.setState({data: Object.assign({}, this.state.data, response.data)}); 
+                  window.alert("Subscription preferences saved");
+                },
             (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
           );
     };
+
+    copyToClipboard() {
+        var url = window.abe_url + this.state.data.ics_url
+        copy(url);
+        // this.props.icsUrlCopiedToClipboard(url);
+        alert("Link copied to clipboard");
+    }
 
     render(){
       return(
@@ -68,6 +81,8 @@ export default class SubscriptionEditorPage extends React.Component {
                 <TagPane contentClass='import-filters' {...this.props} possibleLabels={this.props.labels} selectedLabels={this.state.data.labels} labelToggled={this.labelToggled}/>
                 <br/>
                 <input type="submit" className="button submit" value="Submit" onClick={this.submitSubscription}/>
+                <br/>
+                <input type="submit" className="button submit" value="Copy feed URL" onClick={this.copyToClipboard}/>
             </div>
         </div>
       )

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -1,0 +1,59 @@
+// This component allows the user to import a calendar from an ICS feed
+
+import * as React from "react";
+import axios from 'axios';
+import SidebarModes from "../../data/sidebar-modes";
+import TagPane from "../../components/label-pane.jsx";
+import MenuIconButton from '../../components/menu-icon-button.jsx';
+
+export default class SubscriptionEditorPage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            importData: {
+                labels : [],
+                url : '',
+            },
+        };
+        this.props.setSidebarMode(SidebarModes.IMPORT);
+        props.setPageTitlePrefix('Edit Subscription');
+    }
+
+    labelToggled = (labelName) => {
+        let labels = this.state.importData.labels.slice();
+        if (labels.includes(labelName)) {
+            labels.splice(labels.indexOf(labelName),1);
+        } else {
+            labels.push(labelName);
+        }
+        this.setState({importData: Object.assign({}, this.state.importData, {labels})});
+      };
+
+      urlChanged = (e) => {
+          let importData = this.state.importData;
+          importData = Object.assign(importData, {url: e.currentTarget.value});
+          this.setState({importData : importData});
+      };
+
+    submitICS = () => {
+        axios.post(window.abe_url + '/ics/', this.state.importData)
+          .then(
+            (response) => this.props.importSuccess(response, this.state.importData),
+            (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
+          );
+    };
+
+      render(){
+        return(
+          <div className="row expanded page-container">
+              <div className="row content-container">
+                  <h1 className="page-title"><MenuIconButton onClick={this.props.toggleSidebarCollapsed} tooltip="Show/Hide Sidebar"/>Import</h1>
+                  <input required="required" type="url" placeholder=".../example_calendar.ics" className="wide-text-box single-line-text-box medium-text-box" onChange={this.urlChanged}/>
+                  <TagPane contentClass='import-filters' {...this.props} possibleLabels={this.props.labels} selectedLabels={this.state.importData.labels} labelToggled={this.labelToggled}/>
+                  <br/>
+                  <input type="submit" className="button submit" value="Submit" onClick={this.submitICS}/>
+              </div>
+          </div>
+        )
+      }
+}

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -13,10 +13,15 @@ export default class SubscriptionEditorPage extends React.Component {
             data: {
                 labels : [],
                 id : '',
+                ics_url : '',
             },
         };
 
-        Object.assign(this.state.data, this.getIdFromURL(props));
+        axios.get(window.abe_url + '/subscriptions/'+this.getIdFromURL(props))
+          .then(
+              (response) => this.setState({data: Object.assign({}, this.state.data, response.data)}),
+              (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
+            )
 
         this.props.setSidebarMode(SidebarModes.IMPORT);
         props.setPageTitlePrefix('Edit Subscription');
@@ -24,7 +29,7 @@ export default class SubscriptionEditorPage extends React.Component {
 
     getIdFromURL = (props) => {
         if ('match' in props && 'id' in props.match.params) {
-            return {id: props.match.params.id};
+            return props.match.params.id;
         }
         return null;
     };
@@ -46,10 +51,9 @@ export default class SubscriptionEditorPage extends React.Component {
       // };
 
     submitSubscription = () => {
-      console.log(this.state);
       axios.put(window.abe_url + '/subscriptions/'+this.state.data.id, this.state.data)
           .then(
-            (response) => this.props.importSuccess(response, this.state.importData),
+            (response) => window.alert('Successfully saved subscription preferences'),
             (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message)
           );
     };

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -32,7 +32,7 @@ export default class GenerateICSPane extends React.Component {
 
         var labels = this.props.selectedLabels;
 
-        var temp_id = Math.random().toString(16).substring(2, 15) + Math.random().toString(16).substring(2, 15);
+        var temp_id = Math.random().toString(16).substring(2, 12) + Math.random().toString(16).substring(2, 12);
         var temp_url = '/subscriptions/'+temp_id+'/ics'
         this.copyToClipboard(temp_url)
 
@@ -43,13 +43,22 @@ export default class GenerateICSPane extends React.Component {
                 response => {
                     this.setState({data: Object.assign({}, this.state.data, response.data)}); 
                     if (response.data.ics_url != temp_url){
+                        // The server has returned an ICS url that is different than
+                        // the one we preemptively generated. This could happen if the format
+                        // of the URL changes in some future version, or if the server objects
+                        // to our generated ID for some reason and generates its own.
+                        //
+                        // This should never happen, but handling it here allows future changes
+                        // to URL format to be pushed separately to the backend and frontend
+                        // repos, with only slight user inconvenience during the transition.
+
                         this.copyToClipboard(this.state.data.ics_url);   
                         console.warn('Double copy needed because returned ics_url "'+
                             response.data.ics_url+'" did not match expected "'+temp_url+'"')
                     }
                     alert("Link copied to clipboard");
                 },
-                (jqXHR, _textStatus, _errorThrown) =>
+                (_jqXHR, _textStatus, _errorThrown) =>
                     alert('Failed to get Feed URL')
             )
     }

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -3,24 +3,33 @@
 
 import React from 'react';
 import copy from 'copy-to-clipboard';
+import axios from 'axios';
 import { OutboundLink } from 'react-ga';
+
 
 export default class GenerateICSPane extends React.Component {
 
     constructor(props) {
         super(props);
         this.copyToClipboard = this.copyToClipboard.bind(this);
+        this.getFeedUrl = this.getFeedUrl.bind(this);
     }
 
-    copyToClipboard() {
-        if (this.props.selectedLabels.length > 0) {
-            let url = window.abe_url + '/ics/?labels=' + this.props.selectedLabels.join(',');
-            copy(url);
-            this.props.icsUrlCopiedToClipboard(url);
-            alert("Link copied to clipboard");
-        } else {
-            alert('You must select at least one event tag.')
-        }
+    getFeedUrl() {
+        var labels = this.props.selectedLabels;
+        var url = window.abe_url + '/subscriptions/'
+        axios.post(url, {'labels': labels})
+            .then(
+                _response => this.copyToClipboard(window.abe_url + _response.data.ics_url),
+                (jqXHR, _textStatus, _errorThrown) =>
+                    alert('Failed to get Feed URL')
+            )
+    }
+
+    copyToClipboard(url) {
+        copy(url);
+        this.props.icsUrlCopiedToClipboard(url);
+        alert("Link copied to clipboard");
     }
 
     render() {
@@ -35,7 +44,7 @@ export default class GenerateICSPane extends React.Component {
                         target="_blank">
                         instructions
                     </OutboundLink>).</span>
-                <a className="ics-copy-to-clipboard" title="Copy feed URL" alt="Copy feed URL" onClick={this.copyToClipboard}>Copy link to clipboard</a>
+                <a className="ics-copy-to-clipboard" title="Copy feed URL" alt="Copy feed URL" onClick={this.getFeedUrl}>Copy link to clipboard</a>
 
             </div>
         )

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -13,6 +13,14 @@ export default class GenerateICSPane extends React.Component {
         super(props);
         this.copyToClipboard = this.copyToClipboard.bind(this);
         this.getFeedUrl = this.getFeedUrl.bind(this);
+
+        this.state = {
+            data: {
+                labels : [],
+                id : '',
+                ics_url : '',
+            },
+        };
     }
 
     getFeedUrl() {
@@ -20,13 +28,17 @@ export default class GenerateICSPane extends React.Component {
         var url = window.abe_url + '/subscriptions/'
         axios.post(url, {'labels': labels})
             .then(
-                _response => this.copyToClipboard(window.abe_url + _response.data.ics_url),
+                response => {
+                    this.setState({data: Object.assign({}, this.state.data, response.data)}); 
+                    this.copyToClipboard()
+                },
                 (jqXHR, _textStatus, _errorThrown) =>
                     alert('Failed to get Feed URL')
             )
     }
 
-    copyToClipboard(url) {
+    copyToClipboard() {
+        var url = window.abe_url + this.state.data.ics_url
         copy(url);
         this.props.icsUrlCopiedToClipboard(url);
         alert("Link copied to clipboard");
@@ -48,6 +60,8 @@ export default class GenerateICSPane extends React.Component {
                 <br/><br/>
                 <input type="submit" className="button submit" value="Copy feed URL" onClick={this.getFeedUrl}/>
 
+                {this.state.data.id.length > 0 && 
+                    <a href={'/subscription/'+this.state.data.id} className="ics-copy-to-clipboard" title="Edit feed preferences" alt="Edit feed preferences">Edit feed preferences</a>}
             </div>
         )
     }

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -32,7 +32,9 @@ export default class GenerateICSPane extends React.Component {
 
         var labels = this.props.selectedLabels;
 
-        var temp_id = Math.random().toString(16).substring(2, 12) + Math.random().toString(16).substring(2, 12);
+        var temp_id = Math.random().toString(16).substring(2, 12)
+            + Math.random().toString(16).substring(2, 12)
+            + Math.random().toString(16).substring(2, 12);
         var temp_url = '/subscriptions/'+temp_id+'/ics'
         this.copyToClipboard(temp_url)
 

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -44,7 +44,9 @@ export default class GenerateICSPane extends React.Component {
                         target="_blank">
                         instructions
                     </OutboundLink>).</span>
-                <a className="ics-copy-to-clipboard" title="Copy feed URL" alt="Copy feed URL" onClick={this.getFeedUrl}>Copy link to clipboard</a>
+                {/*<a className="ics-copy-to-clipboard" title="Copy feed URL" alt="Copy feed URL" onClick={this.getFeedUrl}>Copy link to clipboard</a>*/}
+                <br/><br/>
+                <input type="submit" className="button submit" value="Copy feed URL" onClick={this.getFeedUrl}/>
 
             </div>
         )


### PR DESCRIPTION
In order to support the security requirements of the system, as well as to allow the user to edit which labels they can see on a given subscription after they create it, this PR changes the way that subscriptions are handled to ask the server for a unique ID. It also adds a page to enable editing of which labels those subscriptions pull from.

The backend currently supports all of the endpoints needed to make this work, but the data is not yet being stored in the database, so it might be worth holding off until that is implemented before merging this to master.