### PR TITLE
Add default properties to <label-pane>

### DIFF
--- a/src/__test__/label-pane.test.js
+++ b/src/__test__/label-pane.test.js
@@ -11,9 +11,7 @@ describe('LabelPane', () => {
         const component = renderer.create(
             <LabelPane
                 contentClass="css-class"
-                general={{}}
                 possibleLabels={labels}
-                selectedLabels={[]}
             />
         );
         const tree = component.toJSON();
@@ -23,8 +21,6 @@ describe('LabelPane', () => {
         const component = renderer.create(
             <LabelPane
                 contentClass="css-class"
-                general={{}}
-                editable
                 possibleLabels={labels}
                 selectedLabels={['first']}
             />
@@ -36,7 +32,6 @@ describe('LabelPane', () => {
         const component = renderer.create(
             <LabelPane
                 contentClass="css-class"
-                general={{}}
                 editable={false}
                 possibleLabels={labels}
                 selectedLabels={['first']}

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -14,29 +14,31 @@ export default class LabelPane extends React.Component {
     labelClicked = (labelName) => this.props.labelToggled(labelName);
 
     render() {
-        let enableHoverStyle = !this.props.general.isMobile && this.props.editable;
-        const noHoverText = enableHoverStyle ? '' : 'no-hover ';
+        const {editable, possibleLabels, selectedLabels, showUnselected} = this.props;
+        const enableHoverStyle = !this.props.general.isMobile && this.props.editable;
+        const noHoverClass = enableHoverStyle ? '' : 'no-hover ';
         let labelElems = [];
-        if (this.props.possibleLabels && this.props.selectedLabels) {
-            Object.keys(this.props.possibleLabels).forEach((name) => {
-                let tooltip = this.props.possibleLabels[name].description;
-                let selected = this.props.selectedLabels.includes(name);
-                if (selected || this.props.showUnselected) {
-                    let classes = 'label ' + name + (selected ? ' selected' : '');
-                    if (this.props.editable) {
-                        labelElems.push(<button id={'label-' + name} key={name} title={tooltip} type="button"
-                                              className={`button ${noHoverText}${classes}`}
+        if (possibleLabels) {
+            Object.keys(possibleLabels).forEach((name) => {
+                const tooltip = possibleLabels[name].description;
+                const selected = selectedLabels.includes(name);
+                if (selected || showUnselected) {
+                    const classes = 'label ' + name + (selected ? ' selected' : '');
+                    const id = 'label-' + name;
+                    if (editable) {
+                        labelElems.push(<button id={id} key={name} title={tooltip} type="button"
+                                              className={`button ${noHoverClass}${classes}`}
                                               onClick={() => this.labelClicked(name)}>{name}</button>);
                     } else {
-                        labelElems.push(<span id={'label-' + name} key={name} title={tooltip}
+                        labelElems.push(<span id={id} key={name} title={tooltip}
                                             className={classes}>{name}</span>);
                     }
                 }
             });
         }
         let colorSettings = '';
-        for (let name in this.props.possibleLabels) {
-            let bgColor = this.props.possibleLabels[name].color;
+        for (let name in possibleLabels) {
+            const bgColor = possibleLabels[name].color;
             colorSettings += `.label.button.${name}:not(.no-hover):hover,.label.${name}.selected{background-color:${bgColor};}`;
         }
         return (
@@ -53,6 +55,7 @@ export default class LabelPane extends React.Component {
 
 // Define React prop types for type checking during development
 LabelPane.propTypes = {
+    general: PropTypes.object,
     editable: PropTypes.bool,
     showUnselected: PropTypes.bool,
     possibleLabels: PropTypes.object,
@@ -62,6 +65,9 @@ LabelPane.propTypes = {
 
 // Define default values for React props
 LabelPane.defaultProps = {
+    general: {},
     editable: true,
+    selectedLabels: [],
     showUnselected: true,
+    contentClass: '',
 };


### PR DESCRIPTION
Take advantage of the fact that label-pane has test cases to refactor it some; also incorporate into its API some learnings from trying to figure out how to use it while writing tests.

Specifically, `contentClass`, `general`, and `selectedLabels` now have defaults. This simplifies the test cases some.

## Required
* [x] All new and existing tests pass. (`yarn test`)
* [x] All new code follows the code style of this project. (`yarn lint`)
