### PR TITLE
Re-style tag clouds

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -456,6 +456,10 @@ span.label {
     justify-content: space-between;
 }
 
+.label-selector-list button {
+    border-radius: 8px;
+}
+
 .label:not(.selected) {
     background-color: transparent;
     color: black;

--- a/src/__test__/__snapshots__/label-pane.test.js.snap
+++ b/src/__test__/__snapshots__/label-pane.test.js.snap
@@ -51,6 +51,9 @@ exports[`LabelPane not editable 1`] = `
       id="label-first"
       title="first label"
     >
+      <ion-icon
+        name="pricetag"
+      />
       first
     </span>
     <span
@@ -58,6 +61,9 @@ exports[`LabelPane not editable 1`] = `
       id="label-second"
       title="second label"
     >
+      <ion-icon
+        name="pricetag"
+      />
       second
     </span>
   </div>

--- a/src/__test__/__snapshots__/label-pane.test.js.snap
+++ b/src/__test__/__snapshots__/label-pane.test.js.snap
@@ -7,7 +7,12 @@ exports[`LabelPane matches snapshot 1`] = `
   <style
     type="text/css"
   >
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.first.button:not(.selected){background-color:white;}
+.label.first:not(.button):not(.selected){border-color:red;color:red;}
+.label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
+.label.second.button:not(.selected){background-color:white;}
+.label.second:not(.button):not(.selected){border-color:green;color:green;}
+.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
@@ -19,6 +24,11 @@ exports[`LabelPane matches snapshot 1`] = `
       title="first label"
       type="button"
     >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       first
     </button>
     <button
@@ -28,6 +38,11 @@ exports[`LabelPane matches snapshot 1`] = `
       title="second label"
       type="button"
     >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       second
     </button>
   </div>
@@ -41,7 +56,12 @@ exports[`LabelPane not editable 1`] = `
   <style
     type="text/css"
   >
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.first.button:not(.selected){background-color:white;}
+.label.first:not(.button):not(.selected){border-color:red;color:red;}
+.label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
+.label.second.button:not(.selected){background-color:white;}
+.label.second:not(.button):not(.selected){border-color:green;color:green;}
+.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
@@ -51,9 +71,11 @@ exports[`LabelPane not editable 1`] = `
       id="label-first"
       title="first label"
     >
-      <ion-icon
-        name="pricetag"
-      />
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       first
     </span>
     <span
@@ -61,9 +83,11 @@ exports[`LabelPane not editable 1`] = `
       id="label-second"
       title="second label"
     >
-      <ion-icon
-        name="pricetag"
-      />
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       second
     </span>
   </div>
@@ -77,7 +101,12 @@ exports[`LabelPane with selected labels 1`] = `
   <style
     type="text/css"
   >
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.first.button:not(.selected){background-color:white;}
+.label.first:not(.button):not(.selected){border-color:red;color:red;}
+.label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
+.label.second.button:not(.selected){background-color:white;}
+.label.second:not(.button):not(.selected){border-color:green;color:green;}
+.label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
@@ -89,6 +118,11 @@ exports[`LabelPane with selected labels 1`] = `
       title="first label"
       type="button"
     >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       first
     </button>
     <button
@@ -98,6 +132,11 @@ exports[`LabelPane with selected labels 1`] = `
       title="second label"
       type="button"
     >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
       second
     </button>
   </div>

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -1,56 +1,71 @@
 // This component shows a list of event labels
 
-import * as React from "react";
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
 export default class LabelPane extends React.Component {
-
     constructor(props) {
         super(props);
-        if (props.refreshLabelsIfNeeded)
-            props.refreshLabelsIfNeeded();
+        if (props.refreshLabelsIfNeeded) props.refreshLabelsIfNeeded();
     }
 
-    labelClicked = (labelName) => this.props.labelToggled(labelName);
+    labelClicked = labelName => this.props.labelToggled(labelName);
 
     render() {
-        const {editable, possibleLabels, selectedLabels, showUnselected} = this.props;
+        const { editable, possibleLabels, selectedLabels, showUnselected } = this.props;
+        const labels = possibleLabels || [];
         const enableHoverStyle = !this.props.general.isMobile && this.props.editable;
         const noHoverClass = enableHoverStyle ? '' : 'no-hover ';
         let labelElems = [];
-        if (possibleLabels) {
-            Object.keys(possibleLabels).forEach((name) => {
-                const tooltip = possibleLabels[name].description;
-                const selected = selectedLabels.includes(name);
-                if (selected || showUnselected) {
-                    const classes = 'label ' + name + (selected ? ' selected' : '');
-                    const id = 'label-' + name;
-                    if (editable) {
-                        labelElems.push(<button id={id} key={name} title={tooltip} type="button"
-                                              className={`button ${noHoverClass}${classes}`}
-                                              onClick={() => this.labelClicked(name)}>{name}</button>);
-                    } else {
-                        labelElems.push(<span id={id} key={name} title={tooltip}
-                                            className={classes}>{name}</span>);
-                    }
+        Object.keys(labels).forEach(name => {
+            const tooltip = labels[name].description;
+            const selected = selectedLabels.includes(name);
+            if (selected || showUnselected) {
+                const classes = 'label ' + name + (selected ? ' selected' : '');
+                const id = 'label-' + name;
+                if (editable) {
+                    labelElems.push(
+                        <button
+                            id={id}
+                            key={name}
+                            title={tooltip}
+                            type="button"
+                            className={`button ${noHoverClass}${classes}`}
+                            onClick={() => this.labelClicked(name)}
+                        >
+                            <span className="ion-pricetag">&nbsp;</span>
+                            {name}
+                        </button>
+                    );
+                } else {
+                    labelElems.push(
+                        <span id={id} key={name} title={tooltip} className={classes}>
+                            <span className="ion-pricetag">&nbsp;</span>
+                            {name}
+                        </span>
+                    );
                 }
-            });
-        }
-        let colorSettings = '';
-        for (let name in possibleLabels) {
-            const bgColor = possibleLabels[name].color;
-            colorSettings += `.label.button.${name}:not(.no-hover):hover,.label.${name}.selected{background-color:${bgColor};}`;
+            }
+        });
+        function getLabelCss(name) {
+            const { color } = labels[name];
+            // Joining the list of strings, and then again the caller, is less
+            // efficient, but I found it clearer, and this code is not run much
+            // and hasn't shown up as a hot spot.
+            return [
+                `.label.${name}.button:not(.selected){background-color:white;}`,
+                `.label.${name}:not(.button):not(.selected){border-color:${color};color:${color};}`,
+                // hovered button, or selected
+                `.label.button.${name}:not(.no-hover):hover,.label.${name}.selected{background-color:${color};}`
+            ].join('');
         }
         return (
             <div className={this.props.contentClass}>
-                <style type="text/css">{colorSettings}</style>
-                <div className="label-selector-list">
-                    {labelElems}
-                </div>
+                <style type="text/css">{Object.keys(labels).map(getLabelCss).join('')}</style>
+                <div className="label-selector-list">{labelElems}</div>
             </div>
-        )
+        );
     }
-
 }
 
 // Define React prop types for type checking during development
@@ -60,7 +75,7 @@ LabelPane.propTypes = {
     showUnselected: PropTypes.bool,
     possibleLabels: PropTypes.object,
     selectedLabels: PropTypes.array,
-    contentClass: PropTypes.string,
+    contentClass: PropTypes.string
 };
 
 // Define default values for React props
@@ -69,5 +84,5 @@ LabelPane.defaultProps = {
     editable: true,
     selectedLabels: [],
     showUnselected: true,
-    contentClass: '',
+    contentClass: ''
 };

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -52,16 +52,19 @@ export default class LabelPane extends React.Component {
             // Joining the list of strings, and then again the caller, is less
             // efficient, but I found it clearer, and this code is not run much
             // and hasn't shown up as a hot spot.
+            //
+            // Join w/ '\n', here and in caller, for more readable debugging and
+            // snapshots.
             return [
                 `.label.${name}.button:not(.selected){background-color:white;}`,
                 `.label.${name}:not(.button):not(.selected){border-color:${color};color:${color};}`,
                 // hovered button, or selected
                 `.label.button.${name}:not(.no-hover):hover,.label.${name}.selected{background-color:${color};}`
-            ].join('');
+            ].join('\n');
         }
         return (
             <div className={this.props.contentClass}>
-                <style type="text/css">{Object.keys(labels).map(getLabelCss).join('')}</style>
+                <style type="text/css">{Object.keys(labels).map(getLabelCss).join('\n')}</style>
                 <div className="label-selector-list">{labelElems}</div>
             </div>
         );


### PR DESCRIPTION
In consultation with Jeff:

* Added the closest matching icon from the Ionic framework.
* Unselected tags use the tag color
* [Roundrects](https://www.folklore.org/StoryView.py?story=Round_Rects_Are_Everywhere.txt)!

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [n/a] New code is covered by new or existing tests.
* [x] Changed code is covered by new or existing tests.
