### PR TITLE
Add trailing commas to multi-line objects and arrays

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,11 +1,11 @@
-env:
-  browser: true
-
 parser: babel-eslint
 
 extends:
   - eslint:recommended
   - plugin:react/recommended
+
+env:
+  browser: true
 
 # see https://eslint.org/docs/user-guide/configuring#specifying-globals
 globals:
@@ -18,6 +18,9 @@ rules:
   react/no-find-dom-node: warn
   react/prop-types: off           # TODO: #123
   react/jsx-no-target-blank: off  # TODO: is this a legitimate error?
+  # from airbnb style <https://github.com/airbnb/javascript>:
+  # TODO: change this to an error after the redux branch is merged
+  comma-dangle: [warn, always-multiline]
 
 overrides:
   # server:

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ You can also run `jest` and `jest --watch`, if `./node_modules/.bin` is on your
 ## Lint
 
 `yarn lint` runs [ESLint](https://eslint.org/) against the client code (in
-`./src`). It doesn't check the server code — but see #125 before putting too
-much time into that.
+`./src`).
+
+`yarn format` fixes lint errors that `eslint --fix` can fix.
 
 ## Supporters
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "webpack-dev-server --inline --hot",
     "lint": "$npm_execpath run lint:js && $npm_execpath run lint:markdown",
     "lint:js": "eslint --cache --ext .js,.jsx src *.js",
+    "format": "eslint --fix --ext .js,.jsx src *.js && $npm_execpath run lint:markdown --fix",
     "lint:markdown": "markdownlint *.md && markdownlint .github/PULL_REQUEST_TEMPLATE.md -c .github/.markdownlintrc",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ const routes = [
   '/edit/:id',
   '/edit/:sid/:rec_id',
   '/view/:id',
-  '/subscription/:id'
+  '/subscription/:id',
 ];
 
 app.get(routes, function(req, res) {

--- a/src/__test__/label-pane.test.js
+++ b/src/__test__/label-pane.test.js
@@ -5,7 +5,7 @@ import LabelPane from '../components/label-pane';
 describe('LabelPane', () => {
     const labels = {
         first: { color: 'red', description: 'first label' },
-        second: { color: 'green', description: 'second label' }
+        second: { color: 'green', description: 'second label' },
     };
     test('matches snapshot', () => {
         const component = renderer.create(

--- a/src/components/plain-english-recurrence.jsx
+++ b/src/components/plain-english-recurrence.jsx
@@ -13,13 +13,13 @@ export default class PlainEnglishRecurrence extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            start: this.props.start
+            start: this.props.start,
         };
         this.frequencyFormat = {
             DAILY: 'day',
             WEEKLY: 'week',
             MONTHLY: 'month',
-            YEARLY: 'year'
+            YEARLY: 'year',
         };
         this.weekdayFormat = {
             SU: 'Sun',
@@ -28,14 +28,14 @@ export default class PlainEnglishRecurrence extends React.Component {
             WE: 'Wed',
             TH: 'Thu',
             FR: 'Fri',
-            SA: 'Sat'
+            SA: 'Sat',
         };
     }
-    
+
     getEvery = () => this.props.recurrence.interval === 1
             ? this.props.recurrence.frequency.toString().toLowerCase() + ' '
             : 'every ' + this.props.recurrence.interval + ' ' + this.frequencyFormat[this.props.recurrence.frequency] + 's ';
-    
+
     getOn = () => {
         if (this.props.recurrence.frequency === 'DAILY' || this.props.recurrence.frequency === 'YEARLY') {
             return ''

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,36 +10,36 @@ var config = {
     output: {
         path: BUILD_DIR,
         publicPath: '/public/build/',
-        filename: 'bundle.js'
+        filename: 'bundle.js',
     },
     module: {
         loaders: [
             {
                 test: /\.js$/,
                 use: ["source-map-loader"],
-                enforce: "pre"
+                enforce: "pre",
             },
             {
                 test: /\.jsx?/,
                 include: APP_DIR,
-                loader: 'babel-loader'
-            }
-        ]
+                loader: 'babel-loader',
+            },
+        ],
     },
     plugins: [
         new webpack.EnvironmentPlugin({
             ABE_URL: 'http://localhost:3000/',
             DEBUG: false,
-            GA_ID: null
-        })
+            GA_ID: null,
+        }),
     ],
     devServer: {
         contentBase: ['./public', '.'],
-        historyApiFallback: true
+        historyApiFallback: true,
     },
     resolve: {
-        extensions: ['.js', '.jsx']
-    }
+        extensions: ['.js', '.jsx'],
+    },
 };
 
 module.exports = config;


### PR DESCRIPTION
Enable the [comma-dangle](https://eslint.org/docs/rules/comma-dangle.html) eslint rule.

Add `yarn format` to fix eslint issues.

Fix a handful of comma-dangle issues.

Note: a couple of concessions are made, in order to prevent a large number of changes that woud likely cause merge conflicts with outstanding branches:
1. comma-dangle is a warning, not an error
2. files in src aren't fixed

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [x] New code is covered by new or existing tests.
* [x] Changed code is covered by new or existing tests.