### PR TITLE
Invalid events weren't showing alerts

### DIFF
--- a/src/pages/add-edit/add-edit-page.jsx
+++ b/src/pages/add-edit/add-edit-page.jsx
@@ -96,18 +96,20 @@ export default class AddEditEventPage extends React.Component {
     validateInput = () => {
       if (this.state.eventData.title.length === 0) {
         alert('Event Title is required');
-        if (this.state.eventData.title.length === 0) {
-          alert('Event must have a title');
-          return false;
-        }
-
-        if (this.state.eventData.labels.length === 0) {
-          alert('Event must have at least one label');
-          return false;
-        }
-
-        return true;
+        return false;
       }
+
+      if (this.state.eventData.title.length === 0) {
+        alert('Event must have a title');
+        return false;
+      }
+
+      if (this.state.eventData.labels.length === 0) {
+        alert('Event must have at least one label');
+        return false;
+      }
+
+      return true;
     };
 
     saveButtonClicked = () => {


### PR DESCRIPTION
`AddEditEventPage.validateInput()` was ignoring the rest of the tests if the title was non-empty.

This would be a great spot to add tests, but I foundered on `import MenuIconSVG from 'svg-react-loader?name=Icon!../../assets/menu-icon.svg';` in `menu-icon-button.jsx` not working in Jest, and timed out on workarounds / solutions.

Instead, I tested some of the cases manually.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.