### PR TITLE
Package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "fullcalendar": "^3.4.0",
     "http-server": "0.10.0",
     "input-moment": "git+https://github.com/kylecombes/input-moment.git",
-    "isomorphic-fetch": "latest",
     "jquery": "^3.2.1",
     "moment": "^2.18.1",
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "copy-to-clipboard": "^3.0.6",
     "css-loader": "^0.28.4",
     "deepcopy": "^0.6.3",
+    "dotenv": "^5.0.0",
     "expose": "^0.1.4",
     "expose-loader": "^0.7.3",
     "express": "^4.15.3",
@@ -74,11 +75,11 @@
     "svg-react-loader": "^0.4.4",
     "typescript": "^2.4.1",
     "ultra-responsive-calendar": "https://github.com/kylecombes/ultra-responsive-calendar.git",
-    "webpack": "^2.6.1"
+    "webpack": "^2.6.1",
+    "webpack-dev-middleware": "^2.0.4"
   },
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
-    "dotenv": "^5.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.7.0",
@@ -92,7 +93,6 @@
     "redux-devtools": "^3.4.0",
     "regenerator-runtime": "^0.11.1",
     "source-map-loader": "^0.2.3",
-    "webpack-dev-middleware": "^2.0.4",
     "webpack-dev-server": "^2.5.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "blacklist": "^1.1.4",
     "body-parser": "^1.17.2",
+    "commonmark": "^0.27.0",
     "commonmark-react-renderer": "^4.3.3",
     "copy-to-clipboard": "^3.0.6",
     "css-loader": "^0.28.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,6 +1988,15 @@ commonmark@^0.24.0:
     mdurl "~ 1.0.1"
     string.prototype.repeat "^0.2.0"
 
+commonmark@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.27.0.tgz#d86c262b962821e9483c69c547bc58840c047b34"
+  dependencies:
+    entities "~ 1.1.1"
+    mdurl "~ 1.0.1"
+    minimist "~ 1.2.0"
+    string.prototype.repeat "^0.2.0"
+
 compare-versions@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
@@ -5891,7 +5900,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, "minimist@~ 1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 


### PR DESCRIPTION
a862c48 *Remove isomorphic-fetch@latest from deps*

This conflicted with isomorphic-fetch@2.2.1, hoisted from flux#fbjs#isomorphic-fetch, and was skipped with a warning:

```
warning Pattern ["isomorphic-fetch@latest"] is trying to unpack in the same destination "/Users/osteele/Library/Caches/Yarn/v1/npm-isomorphic-fetch-2.2.1-611ae1acf14f5e81f729507472819fe9733558a9" as pattern ["isomorphic-fetch@^2.1.1"]. This could result in non-deterministic behavior, skipping.
```

e7a3449 *Add dep on commonmark-react-renderer@4.3.4*

Fixes a peer dependency warning

```
warning " > commonmark-react-renderer@4.3.4" has unmet peer dependency "commonmark@^0.27.0 || ^0.26.0 || ^0.24.0".
```

991841e *Move a couple packages from devDepencies to dependencies*

Tested via `yarn install --production && yarn start`.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [n/a] New code is covered by new or existing tests.
* [n/a] Changed code is covered by new or existing tests.