### PR TITLE
Update app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,19 +1,14 @@
 {
-  "name": "abe-web",
-  "description": "Web frontend for Olin College's Amorphous Blob of Events",
-  "scripts": {
-  },
-  "env": {
-    "ABE_URL": "https://abe.olin.build"
-  },
-  "formation": {
-  },
-  "addons": [
-
-  ],
-  "buildpacks": [
-    {
-      "url": "heroku/nodejs"
-    }
-  ]
-}
+    "name": "abe-web",
+    "description": "Web frontend for Olin College's Amorphous Blob of Events",
+    "repository": "https://github.com/olinlibrary/abe-web",
+    "success_url": "/",
+    "env": {
+        "ABE_URL": "https://abe-dev.olin.build"
+    },
+    "buildpacks": [
+        {
+            "url": "heroku/nodejs"
+        }
+    ]
+  }


### PR DESCRIPTION
The main point of this commit is to change the default `ABE_URL` value to `https://abe-dev.olin.build`, so that newly-minted PR apps point to dev instead of prod.

Also took the opportunity to add `repository` and `success_url` properties as documented [here](https://devcenter.heroku.com/articles/app-json-schema), and remove some of the optional empty values.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [n/a] New code is covered by new or existing tests.
* [n/a] Changed code is covered by new or existing tests.
