### PR TITLE
Remove exemption for eslint import/extensions rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,7 +22,6 @@ rules:
   camelcase: warn
   consistent-return: warn
   guard-for-in: warn
-  import/extensions: warn
   import/first: warn
   import/no-extraneous-dependencies: warn
   import/no-unresolved: warn

--- a/src/containers/sidebar-container.js
+++ b/src/containers/sidebar-container.js
@@ -1,7 +1,7 @@
 // This container is a sort of middleware between the React sidebar and the Redux data store
 
 import { connect } from 'react-redux';
-import Sidebar from '../sidebar/sidebar.jsx';
+import Sidebar from '../sidebar/sidebar';
 import * as Actions from '../data/actions';
 import { push } from 'react-router-redux';
 import ReactGA from 'react-ga';

--- a/src/pages/add-edit/add-edit-page.jsx
+++ b/src/pages/add-edit/add-edit-page.jsx
@@ -4,14 +4,14 @@ import * as React from 'react';
 import moment from 'moment';
 import deepcopy from 'deepcopy';
 import axios from 'axios';
-import EventVisibilitySelector from './visibility-selector.jsx';
-import SaveCancelButtons from './save-cancel-buttons.jsx';
-import LocationField from './location-field.jsx';
-import EventDateTimeSelector from '../../components/date-time-selector.jsx';
-import EventRecurrenceSelector from './recurrence-selector.jsx';
-import MarkdownEditor from '../../components/markdown-editor.jsx';
-import MenuIconButton from '../../components/menu-icon-button.jsx';
-import LabelPane from '../../components/label-pane.jsx';
+import EventVisibilitySelector from './visibility-selector';
+import SaveCancelButtons from './save-cancel-buttons';
+import LocationField from './location-field';
+import EventDateTimeSelector from '../../components/date-time-selector';
+import EventRecurrenceSelector from './recurrence-selector';
+import MarkdownEditor from '../../components/markdown-editor';
+import MenuIconButton from '../../components/menu-icon-button';
+import LabelPane from '../../components/label-pane';
 import SidebarModes from '../../data/sidebar-modes';
 
 export default class AddEditEventPage extends React.Component {

--- a/src/pages/calendar/calendar-page.jsx
+++ b/src/pages/calendar/calendar-page.jsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import SidebarModes from '../../data/sidebar-modes';
 import UltraResponsiveCalendar from 'ultra-responsive-calendar';
-import CalendarHeader from './calendar-header.jsx';
+import CalendarHeader from './calendar-header';
 
 export default class CalendarPage extends React.Component {
   componentDidMount() {

--- a/src/pages/details/event-details-page.jsx
+++ b/src/pages/details/event-details-page.jsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Markdown from 'react-markdown';
 import SidebarModes from '../../data/sidebar-modes';
-import PlainEnglishRecurrence from '../../components/plain-english-recurrence.jsx';
+import PlainEnglishRecurrence from '../../components/plain-english-recurrence';
 
 export default class EventDetailsPage extends React.Component {
   componentDidMount() {

--- a/src/pages/import/import.jsx
+++ b/src/pages/import/import.jsx
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import axios from 'axios';
 import SidebarModes from '../../data/sidebar-modes';
-import TagPane from '../../components/label-pane.jsx';
-import MenuIconButton from '../../components/menu-icon-button.jsx';
+import TagPane from '../../components/label-pane';
+import MenuIconButton from '../../components/menu-icon-button';
 
 export default class ImportPage extends React.Component {
   constructor(props) {

--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import axios from 'axios';
 import copy from 'copy-to-clipboard';
 import SidebarModes from '../../data/sidebar-modes';
-import TagPane from '../../components/label-pane.jsx';
-import MenuIconButton from '../../components/menu-icon-button.jsx';
+import TagPane from '../../components/label-pane';
+import MenuIconButton from '../../components/menu-icon-button';
 
 export default class SubscriptionEditorPage extends React.Component {
   constructor(props) {

--- a/src/sidebar/filter-pane.jsx
+++ b/src/sidebar/filter-pane.jsx
@@ -1,7 +1,7 @@
 // This component is a sidebar pane/section for filtering events.
 
 import React from 'react';
-import LabelPane from '../components/label-pane.jsx';
+import LabelPane from '../components/label-pane';
 
 export default class FilterPane extends React.Component {
   selectLabels = (allNoneDefault) => {

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -2,15 +2,15 @@
 // changed.
 
 import React, { Component } from 'react';
-import Footer from './footer.jsx';
-import { SidebarHeader } from '../components/sidebar-header.jsx';
-import SidebarItemContainer from './sidebar-item-wrapper.jsx';
-import FilterPane from './filter-pane.jsx';
-import LinkPane from './link-pane.jsx';
-import GenerateICSPane from './generate-ics-pane.jsx';
-import MarkdownGuide from './markdown-guide.jsx';
-import EventActionsPane from './event-actions-pane.jsx';
-import LabelPane from '../components/label-pane.jsx';
+import Footer from './footer';
+import { SidebarHeader } from '../components/sidebar-header';
+import SidebarItemContainer from './sidebar-item-wrapper';
+import FilterPane from './filter-pane';
+import LinkPane from './link-pane';
+import GenerateICSPane from './generate-ics-pane';
+import MarkdownGuide from './markdown-guide';
+import EventActionsPane from './event-actions-pane';
+import LabelPane from '../components/label-pane';
 
 export default class Sidebar extends Component {
   render() {


### PR DESCRIPTION
Remove the exemption for eslint import/extensions rule (from Airbnb), and fix the sources.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [n/a] New code is covered by new or existing tests.
* [n/a] Changed code is covered by new or existing tests.