### PR TITLE
Chip away at eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,10 +25,6 @@ rules:
   import/no-unresolved: warn
   import/no-webpack-loader-syntax: warn
   import/prefer-default-export: warn
-  jsx-a11y/anchor-is-valid: warn
-  jsx-a11y/click-events-have-key-events: warn
-  jsx-a11y/label-has-for: warn
-  jsx-a11y/no-static-element-interactions: warn
   no-alert: warn
   no-mixed-operators: warn
   no-param-reassign: warn
@@ -47,6 +43,12 @@ rules:
   react/prefer-stateless-function: warn
   react/require-default-props: warn
   react/sort-comp: warn
+
+  # TODO: #118 accessibility
+  jsx-a11y/anchor-is-valid: off
+  jsx-a11y/click-events-have-key-events: off
+  jsx-a11y/label-has-for: off
+  jsx-a11y/no-static-element-interactions: off
 
   # Fixable exceptions to Airbnb style guide.
   indent: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,7 +22,6 @@ rules:
   camelcase: warn
   consistent-return: warn
   guard-for-in: warn
-  import/first: warn
   import/no-unresolved: warn
   import/no-webpack-loader-syntax: warn
   import/prefer-default-export: warn

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,7 @@ globals:
 rules:
   max-len: [warn, { code: 120 }]
   # exceptions from eslint:recommended:
-  no-unused-vars: [error, { argsIgnorePattern: "^_" }]
+  no-unused-vars: [error, argsIgnorePattern: "^_" ]
   # exceptions from plugin:react/recommended:
   react/no-find-dom-node: warn
   react/prop-types: off           # TODO: #123
@@ -35,7 +35,7 @@ rules:
   no-plusplus: warn
   no-restricted-globals: warn
   no-restricted-syntax: warn
-  no-underscore-dangle: warn
+  no-underscore-dangle: [error, allow: [__REDUX_DEVTOOLS_EXTENSION_COMPOSE__]]
   no-use-before-define: warn
   prefer-destructuring: warn
   react/forbid-prop-types: warn

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,7 +23,6 @@ rules:
   consistent-return: warn
   guard-for-in: warn
   import/first: warn
-  import/no-extraneous-dependencies: warn
   import/no-unresolved: warn
   import/no-webpack-loader-syntax: warn
   import/prefer-default-export: warn

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "input-moment": "git+https://github.com/kylecombes/input-moment.git",
     "jquery": "^3.2.1",
     "moment": "^2.18.1",
+    "prop-types": "^15.6.1",
     "react": "^15.6.1",
     "react-dnd": "^2.4.0",
     "react-dom": "^15.6.1",

--- a/src/containers/calendar-container.js
+++ b/src/containers/calendar-container.js
@@ -1,6 +1,7 @@
 // This container is a sort of middleware between the React page and the Redux data store
 
 import { connect } from 'react-redux';
+import moment from 'moment';
 import {
   setSidebarMode,
   toggleSidebarCollapsed,
@@ -13,7 +14,6 @@ import {
   viewEvent,
 } from '../data/actions';
 import CalendarPage from '../pages/calendar/calendar-page';
-import moment from 'moment';
 
 const getVisibleEvents = (events, visibleLabels, allLabels) => {
   // Filter out events that are not labeled with currently visible labels

--- a/src/containers/import-container.js
+++ b/src/containers/import-container.js
@@ -1,13 +1,13 @@
 // This container is a sort of middleware between the React import component and the Redux data store
 
 import { connect } from 'react-redux';
+import * as ga from 'react-ga';
 import {
   setSidebarMode,
   toggleSidebarCollapsed,
   setPageTitlePrefix,
 } from '../data/actions';
 import ImportPage from '../pages/import/import';
-import * as ga from 'react-ga';
 
 // This function passes values/objects from the Redux state to the React component as props
 const mapStateToProps = state => ({

--- a/src/containers/sidebar-container.js
+++ b/src/containers/sidebar-container.js
@@ -1,10 +1,10 @@
 // This container is a sort of middleware between the React sidebar and the Redux data store
 
 import { connect } from 'react-redux';
-import Sidebar from '../sidebar/sidebar';
-import * as Actions from '../data/actions';
 import { push } from 'react-router-redux';
 import ReactGA from 'react-ga';
+import Sidebar from '../sidebar/sidebar';
+import * as Actions from '../data/actions';
 
 // This function passes values/objects from the Redux state to the React component as props
 const mapStateToProps = state => ({

--- a/src/containers/subscription-container.js
+++ b/src/containers/subscription-container.js
@@ -1,13 +1,13 @@
 // This container is a sort of middleware between the React import component and the Redux data store
 
 import { connect } from 'react-redux';
+import * as ga from 'react-ga';
 import {
   setSidebarMode,
   toggleSidebarCollapsed,
   setPageTitlePrefix,
 } from '../data/actions';
 import SubscriptionEditorPage from '../pages/subscription/subscription';
-import * as ga from 'react-ga';
 
 // This function passes values/objects from the Redux state to the React component as props
 const mapStateToProps = state => ({

--- a/src/data/setup-store.js
+++ b/src/data/setup-store.js
@@ -7,13 +7,13 @@ import SidebarMode from './sidebar-modes';
 
 
 export default function setupStore(history) {
-  const DEBUG = process.env.DEBUG || false;
-  const GA_ID = process.env.GA_ID;
+  const debug = process.env.DEBUG || false;
+  const googleAnalyticsId = process.env.GA_ID;
 
   const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
   const initialState = {
     general: {
-      debug: window.debug,
+      debug,
       isMobile,
       pageTitlePrefix: null,
       pageTitleSuffix: 'Olin College Events',
@@ -63,11 +63,8 @@ export default function setupStore(history) {
     ? initialState.calendar.possibleViewModes['3-Day']
     : initialState.calendar.possibleViewModes.Month;
 
-  // Google Analytics
-  if (GA_ID) {
-    ReactGA.initialize(GA_ID, {
-      debug: DEBUG,
-    });
+  if (googleAnalyticsId) {
+    ReactGA.initialize(googleAnalyticsId, { debug });
     history.listen((event) => {
       // Dispatch page changes to Google Analytics
       ReactGA.set({ page: event.pathname });
@@ -78,7 +75,7 @@ export default function setupStore(history) {
   }
 
   // Load the Redux middleware if the Redux devtools extension is available
-  const middleware = (DEBUG && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__)
+  const middleware = (debug && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__)
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(applyMiddleware(
       thunkMiddleware, // lets us dispatch() functions
       routerMiddleware(history),

--- a/src/pages/calendar/calendar-page.jsx
+++ b/src/pages/calendar/calendar-page.jsx
@@ -1,8 +1,8 @@
 // This page displays the calendar (it's the home page)
 
 import * as React from 'react';
-import SidebarModes from '../../data/sidebar-modes';
 import UltraResponsiveCalendar from 'ultra-responsive-calendar';
+import SidebarModes from '../../data/sidebar-modes';
 import CalendarHeader from './calendar-header';
 
 export default class CalendarPage extends React.Component {


### PR DESCRIPTION
## Description
80d9ee5 *Fix a lint error*

Also `initialState` was initialized from `window.debug` instead of `process.env.DEBUG`.

bf90c26 *Disable a11y warnings*

#118 represents these; they don't need to clutter up the log until we're ready to tackle them.

fd07565 *Teach eslint about __REDUX_DEVTOOLS_EXTENSION_COMPOSE__*


28efe3a *Obey eslint import/first rule*


03a6085 *Add prop-types to package.json.dev*

Per https://reactjs.org/blog/2017/04/07/react-v15.5.0.html

Eliminates a number of eslint warnings:

```
warning  'prop-types' should be listed in the project's dependencies. Run 'npm i -S prop-types' to add it  import/no-extraneous-dependencies
```

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [n/a] New code is covered by new or existing tests.
* [n/a] Changed code is covered by new or existing tests.