### PR TITLE
More add/edit page fixes

### DIFF
--- a/src/containers/add-edit-container.js
+++ b/src/containers/add-edit-container.js
@@ -9,6 +9,7 @@ import {
   deleteCurrentEvent,
   eventSavedSuccessfully,
   eventSaveFailed,
+  clearCurrentEvent,
 } from '../data/actions';
 import AddEditEventPage from '../pages/add-edit/add-edit-page';
 
@@ -46,6 +47,9 @@ const mapDispatchToProps = dispatch => ({
   },
   eventSaveFailed: (event, error) => {
     dispatch(eventSaveFailed(event, error));
+  },
+  clearCurrentEvent: () => {
+    dispatch(clearCurrentEvent());
   },
 });
 

--- a/src/containers/event-details-container.js
+++ b/src/containers/event-details-container.js
@@ -5,6 +5,7 @@ import {
   setSidebarMode,
   setPageTitlePrefix,
   getEventDataViaUrlParams,
+  clearCurrentEvent,
 } from '../data/actions';
 import EventDetailsPage from '../pages/details/event-details-page';
 
@@ -23,6 +24,9 @@ const mapDispatchToProps = dispatch => ({
   },
   setPageTitlePrefix: (title) => {
     dispatch(setPageTitlePrefix(title));
+  },
+  clearCurrentEvent: () => {
+    dispatch(clearCurrentEvent());
   },
 });
 

--- a/src/containers/sidebar-container.js
+++ b/src/containers/sidebar-container.js
@@ -27,7 +27,6 @@ const mapDispatchToProps = dispatch => ({
       action: 'click',
       label: 'User clicked the Olin logo to return to the Home view',
     });
-    dispatch(Actions.clearCurrentEvent());
     dispatch(push('/'));
   },
   addEvent: () => {

--- a/src/pages/add-edit/add-edit-page.jsx
+++ b/src/pages/add-edit/add-edit-page.jsx
@@ -154,6 +154,7 @@ export default class AddEditEventPage extends React.Component {
         } else {
           url = `${window.abe_url}/events/${eventData.id || eventData.sid}`;
         }
+        delete eventData.color; // Don't send the color used for rendering the calendar
         requestMethod = axios.put;
       } else { // We're adding a new event
         url = `${window.abe_url}/events/`;

--- a/src/pages/add-edit/add-edit-page.jsx
+++ b/src/pages/add-edit/add-edit-page.jsx
@@ -88,6 +88,10 @@ export default class AddEditEventPage extends React.Component {
     // TODO: If the event is recurring but newProps.match.params.recId is not defined, copy the data to seriesData
   }
 
+  componentWillUnmount() {
+    this.props.clearCurrentEvent();
+  }
+
   receivedSuccessfulSeriesDataResponse = (response) => {
     const seriesData = response.data;
 

--- a/src/pages/add-edit/add-edit-page.jsx
+++ b/src/pages/add-edit/add-edit-page.jsx
@@ -202,8 +202,8 @@ export default class AddEditEventPage extends React.Component {
   labelToggled = (labelName) => {
     const labels = this.state.eventData.labels.slice(); // Make a copy of the list
     const labelIndex = labels.indexOf(labelName);
-    if (labelIndex > 0) { // The label is already on the event
-      labels.splice(labelName, 1); // Remove the label
+    if (labelIndex > -1) { // The label is already on the event
+      labels.splice(labelIndex, 1); // Remove the label
     } else {
       labels.push(labelName); // Add the label
     }

--- a/src/pages/details/event-details-page.jsx
+++ b/src/pages/details/event-details-page.jsx
@@ -18,6 +18,10 @@ export default class EventDetailsPage extends React.Component {
     this.props.setSidebarMode(SidebarModes.VIEW_EVENT);
   }
 
+  componentWillUnmount() {
+    this.props.clearCurrentEvent();
+  }
+
   render() {
     if (this.props.eventData) {
       const oneDay = this.props.eventData.start.diff(this.props.eventData.end, 'days') === 0;


### PR DESCRIPTION
## Description
* Stopped `color` from being sent to server on event save (caused 500 response)
* Fixed issue toggling labels
* Fixed current event data not being cleared when navigating between pages not using the sidebar home button

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.
