### PR TITLE
Add a Labels page, for admins to review labels

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -50,7 +50,7 @@ rules:
   jsx-a11y/no-static-element-interactions: off
 
   # Fixable exceptions to Airbnb style guide.
-  indent: off
+  indent: warn
   react/jsx-indent: off
 
 overrides:

--- a/src/__test__/add-edit-page.test.jsx
+++ b/src/__test__/add-edit-page.test.jsx
@@ -5,10 +5,10 @@ import moment from 'moment';
 import AddEditEventPage from '../pages/add-edit/add-edit-page';
 
 describe('AddEditEventPage', () => {
-    // TODO: test the snapshot. This requires mocking moment or
-    // EventDateTimeSelector, or modifying the latter to accept the datetime as
-    // a property.
-    test.skip('matches snapshot', () => {
+  // TODO: test the snapshot. This requires mocking moment or
+  // EventDateTimeSelector, or modifying the latter to accept the datetime as
+  // a property.
+  test.skip('matches snapshot', () => {
     const event = {
       title: 'An event title',
       labels: ['label'],

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -14,6 +14,7 @@ import SidebarContainer from './containers/sidebar-container';
 import AddEditContainer from './containers/add-edit-container';
 import ViewEventContainer from './containers/event-details-container';
 import ImportContainer from './containers/import-container';
+import LabelsContainer from './containers/labels-container';
 import SubscriptionContainer from './containers/subscription-container';
 
 // Remove trailing slash, if present
@@ -42,6 +43,7 @@ ReactDOM.render(
             <Route path="/edit/:id?/:recId?" component={AddEditContainer} />
             <Route path="/view/:id/:recId?" component={ViewEventContainer} />
             <Route exact path="/import" component={ImportContainer} />
+            <Route exact path="/labels" component={LabelsContainer} />
             <Route path="/subscription/:id" component={SubscriptionContainer} />
           </Switch>
         </Router>
@@ -50,4 +52,3 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('app'),
 );
-

--- a/src/containers/labels-container.js
+++ b/src/containers/labels-container.js
@@ -4,15 +4,15 @@ import { refreshLabelsIfNeeded, updateLabel } from '../data/actions';
 
 // Pass data from the Redux state to the React component
 const mapStateToProps = state => ({
-    labels: state.labels.labelList,
+  labels: state.labels.labelList,
 });
 
 // Pass functions from src/data/actions.jsx to the React component
 const mapDispatchToProps = dispatch => ({
-    updateLabel: (data) => {
-        dispatch(updateLabel(data));
-    },
-    refreshLabelsIfNeeded,
+  updateLabel: (data) => {
+    dispatch(updateLabel(data));
+  },
+  refreshLabelsIfNeeded,
 });
 
 // Connect props to Redux state and actions

--- a/src/containers/labels-container.js
+++ b/src/containers/labels-container.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import LabelsPage from '../pages/labels/labels';
+import { refreshLabelsIfNeeded, updateLabel } from '../data/actions';
+
+// Pass data from the Redux state to the React component
+const mapStateToProps = state => ({
+    labels: state.labels.labelList,
+});
+
+// Pass functions from src/data/actions.jsx to the React component
+const mapDispatchToProps = dispatch => ({
+    updateLabel: (data) => {
+        dispatch(updateLabel(data));
+    },
+    refreshLabelsIfNeeded,
+});
+
+// Connect props to Redux state and actions
+const LabelsContainer = connect(mapStateToProps, mapDispatchToProps)(LabelsPage);
+
+export default LabelsContainer;

--- a/src/containers/labels-container.js
+++ b/src/containers/labels-container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import LabelsPage from '../pages/labels/labels';
-import { refreshLabelsIfNeeded, updateLabel } from '../data/actions';
+import { refreshLabelsIfNeeded, setPageTitlePrefix, setSidebarMode, updateLabel } from '../data/actions';
+import SidebarModes from '../data/sidebar-modes';
 
 // Pass data from the Redux state to the React component
 const mapStateToProps = state => ({
@@ -9,10 +10,16 @@ const mapStateToProps = state => ({
 
 // Pass functions from src/data/actions.jsx to the React component
 const mapDispatchToProps = dispatch => ({
+  refreshLabelsIfNeeded,
   updateLabel: (data) => {
     dispatch(updateLabel(data));
   },
-  refreshLabelsIfNeeded,
+  setPageTitlePrefix: (title) => {
+    dispatch(setPageTitlePrefix(title));
+  },
+  setSidebarMode: () => {
+    dispatch(setSidebarMode(SidebarModes.EMPTY));
+  },
 });
 
 // Connect props to Redux state and actions

--- a/src/data/actions.js
+++ b/src/data/actions.js
@@ -15,12 +15,12 @@ export const ActionTypes = {
   TOGGLE_SIDEBAR_VISIBILITY: 'TOGGLE_SIDEBAR_VISIBILITY', // Toggles the visibility of the app sidebar
   // Calendar view
   SET_FOCUSED_DATE: 'SET_FOCUSED_DATE', // Sets the day the calendar view is ensuring is shown (changing this changes
-                                        // which time period is shown on the calendar)
+  // which time period is shown on the calendar)
   SET_FILTER_LABELS: 'SET_FILTER_LABELS', // Sets which labels are selected as part of the event filter
   FILTER_LABEL_TOGGLED: 'FILTER_LABEL_TOGGLED', // Toggles whether or not a specific label is selected as part
-                                                // of the event filter
+  // of the event filter
   SET_FILTER_LABEL_SELECTED: 'SET_FILTER_LABEL_SELECTED', // Sets whether or not a specific label is selected as part
-                                                          // of the event filter
+  // of the event filter
   SET_VIEW_MODE: 'SET_VIEW_MODE', // Sets which view mode (month, week, day, etc) the calendar is in
   // Event data
   SET_CURRENT_EVENT: 'SET_CURRENT_EVENT', // Keeps track of the data for the event currently being viewed or edited
@@ -35,7 +35,7 @@ export const ActionTypes = {
   SET_LABELS: 'SET_LABELS', // Sets the label data using data from a server response
   // ICS
   GENERATE_ICS_FEED: 'GENERATE_ICS_FEED', // Triggers generation of an ICS feed with current filter applied and copies
-                                          // URL to clipboard
+  // URL to clipboard
 };
 
 // Sections:

--- a/src/data/actions.js
+++ b/src/data/actions.js
@@ -516,4 +516,12 @@ export function labelVisibilityToggled(labelName) {
   return { type: ActionTypes.FILTER_LABEL_TOGGLED, labelName };
 }
 
+export function updateLabel(data) {
+  return () => {
+    // TODO: update model on success
+    axios.post(`${window.abe_url}/labels/${data.id}`, data)
+      .catch(error => alert(`Update label failed:\n${error}`));
+  };
+}
+
 // ########## End Labels-Related Actions ########## //

--- a/src/data/sidebar-modes.js
+++ b/src/data/sidebar-modes.js
@@ -43,6 +43,14 @@ const SidebarModes = {
     EVENT_ACTIONS: false,
     EVENT_LABELS_PANE: false,
   },
+  EMPTY: {
+    LINK_PANE: false,
+    FILTER_PANE: false,
+    GENERATE_ICS_PANE: false,
+    MARKDOWN_GUIDE: false,
+    EVENT_ACTIONS: false,
+    EVENT_LABELS_PANE: true,
+  },
 };
 
 export default SidebarModes;

--- a/src/pages/labels/labels.jsx
+++ b/src/pages/labels/labels.jsx
@@ -3,15 +3,9 @@
 // It's intended to make it easier for an administator to review the labels,
 // their descriptions, colors, and flags.
 //
-//
 // This isn't part of the public UI. It's not protected by auth, since it
 // doesn't (yet) allow modifications to the set of labels, but there's no link
 // to it.
-//
-// It could be added as a user-visible view:
-//   * Set the sidebar mode
-//   * Set the page title
-//   * Link to it
 
 import * as React from 'react';
 import _ from 'lodash';
@@ -20,6 +14,8 @@ export default class LabelsPage extends React.Component {
   constructor(props) {
     super(props);
     props.refreshLabelsIfNeeded();
+    this.props.setSidebarMode();
+    props.setPageTitlePrefix('Labels');
   }
 
   render() {

--- a/src/pages/labels/labels.jsx
+++ b/src/pages/labels/labels.jsx
@@ -1,0 +1,90 @@
+// This page component displays a list of labels.
+//
+// It's intended to make it easier for an administator to review the labels,
+// their descriptions, colors, and flags.
+//
+//
+// This isn't part of the public UI. It's not protected by auth, since it
+// doesn't (yet) allow modifications to the set of labels, but there's no link
+// to it.
+//
+// It could be added as a user-visible view:
+//   * Set the sidebar mode
+//   * Set the page title
+//   * Link to it
+
+import * as React from 'react';
+import _ from 'lodash';
+
+export default class LabelsPage extends React.Component {
+  constructor(props) {
+    super(props);
+    props.refreshLabelsIfNeeded();
+  }
+
+  render() {
+    if (!this.props.labels) {
+      return <div>loading</div>;
+    }
+    const labels = _.sortBy(Object.values(this.props.labels), ({ name }) => name.toLowerCase());
+    return (
+      <div className="row expanded page-container">
+        <div className="row content-container">
+          <h1 className="page-title">Labels</h1>
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Color</th>
+                <th>Flags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {labels.map(label => (
+                <tr key={label.id}>
+                  <td>{label.name}</td>
+                  <td>{label.description}</td>
+                  <td style={{ backgroundColor: label.color }}>{label.color}</td>
+                  <td>
+                    <LabelFlag
+                      symbol="✔"
+                      value={label.default}
+                      name="Default"
+                      description="Selected when the calendar is loaded"
+                    />
+                    {/* TODO: Update label.public to whatever the property ends up being named */}
+                    <LabelFlag
+                      symbol="👥"
+                      value={label.public}
+                      name="Public"
+                      description="Events with this label are visible otuside Olin"
+                    />
+                    {/* TODO: Update label.protected to whatever the property ends up being named */}
+                    <LabelFlag
+                      symbol="🔒"
+                      value={label.protected}
+                      name="Locked"
+                      description="This label may only be added by an administrator"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+
+const LabelFlag = (props) => {
+  const title = `${props.name}. ${props.description}`;
+  return props.value ? (
+    <span role="img" title={title} aria-label={title} style={{ cursor: 'pointer' }}>
+      {props.symbol}
+    </span>
+  ) : (
+    <span />
+  );
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,45 +5,45 @@ const BUILD_DIR = path.resolve(__dirname);
 const APP_DIR = path.resolve(__dirname, 'src');
 
 const config = {
-    devtool: 'source-map',
-    entry: `${APP_DIR}/app.jsx`,
-    output: {
-        path: BUILD_DIR,
-        publicPath: '/public/build/',
-        filename: 'bundle.js',
-    },
-    module: {
-        loaders: [
-            {
-                test: /\.js$/,
-                use: ['source-map-loader'],
-                enforce: 'pre',
-            },
-            {
-                test: /\.jsx?$/,
-                include: APP_DIR,
-                loader: 'babel-loader',
-            },
-            {
-                test: /\.svg$/,
-                loader: 'svg-react-loader?name=Icon',
-            },
-        ],
-    },
-    plugins: [
-        new webpack.EnvironmentPlugin({
-            ABE_URL: 'http://localhost:3000/',
-            DEBUG: true,
-            GA_ID: null,
-        }),
+  devtool: 'source-map',
+  entry: `${APP_DIR}/app.jsx`,
+  output: {
+    path: BUILD_DIR,
+    publicPath: '/public/build/',
+    filename: 'bundle.js',
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+      {
+        test: /\.jsx?$/,
+        include: APP_DIR,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.svg$/,
+        loader: 'svg-react-loader?name=Icon',
+      },
     ],
-    devServer: {
-        contentBase: ['./public', '.'],
-        historyApiFallback: true,
-    },
-    resolve: {
-        extensions: ['.js', '.jsx'],
-    },
+  },
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      ABE_URL: 'http://localhost:3000/',
+      DEBUG: true,
+      GA_ID: null,
+    }),
+  ],
+  devServer: {
+    contentBase: ['./public', '.'],
+    historyApiFallback: true,
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
## Description

51257e2 *Add a Labels page, for admins to review labels*

Adds a  Labels page, at `/labels`. This page makes it easier for an administrator to review the labels, their descriptions, colors, and flags.

This page isn't part of the public UI. It's not protected by auth, since it doesn't (yet) allow modifications to the set of labels, but there's no link to it.

f0b01a5 *Change eslint indent from indent to warn*

This turns out to be the easiest way to get editors that respect eslint settings to respect this project's 2-char indentation convention.

30fc4ec *Apply 2-char indentation to a couple of files*

0de0ba3 *Labels page sets sidebar and title*

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [☹️] New code is covered by new or existing tests.
* [☹️] Changed code is covered by new or existing tests.