### PR TITLE
Sort labels

### DIFF
--- a/src/__test__/__snapshots__/label-pane.test.jsx.snap
+++ b/src/__test__/__snapshots__/label-pane.test.jsx.snap
@@ -7,19 +7,19 @@ exports[`LabelPane matches snapshot 1`] = `
   <style
     type="text/css"
   >
-    .label.first.button:not(.selected){background-color:white;}
-    .label.first:not(.button):not(.selected){border-color:red;color:red;}
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
-    .label.second.button:not(.selected){background-color:white;}
-    .label.second:not(.button):not(.selected){border-color:green;color:green;}
-    .label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.label-label-1.button:not(.selected){background-color:white;}
+    .label.label-label-1:not(.button):not(.selected){border-color:red;color:red;}
+    .label.button.label-label-1:not(.no-hover):hover,.label.label-label-1.selected{background-color:red;}
+    .label.label-label-2.button:not(.selected){background-color:white;}
+    .label.label-label-2:not(.button):not(.selected){border-color:green;color:green;}
+    .label.button.label-label-2:not(.no-hover):hover,.label.label-label-2.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
   >
     <button
-      className="button label first"
-      id="label-first"
+      className="button label label-label-1"
+      id="label-1"
       onClick={[Function]}
       title="first label"
       type="button"
@@ -32,8 +32,8 @@ exports[`LabelPane matches snapshot 1`] = `
       first
     </button>
     <button
-      className="button label second"
-      id="label-second"
+      className="button label label-label-2"
+      id="label-2"
       onClick={[Function]}
       title="second label"
       type="button"
@@ -56,19 +56,19 @@ exports[`LabelPane not editable 1`] = `
   <style
     type="text/css"
   >
-    .label.first.button:not(.selected){background-color:white;}
-    .label.first:not(.button):not(.selected){border-color:red;color:red;}
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
-    .label.second.button:not(.selected){background-color:white;}
-    .label.second:not(.button):not(.selected){border-color:green;color:green;}
-    .label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.label-label-1.button:not(.selected){background-color:white;}
+    .label.label-label-1:not(.button):not(.selected){border-color:red;color:red;}
+    .label.button.label-label-1:not(.no-hover):hover,.label.label-label-1.selected{background-color:red;}
+    .label.label-label-2.button:not(.selected){background-color:white;}
+    .label.label-label-2:not(.button):not(.selected){border-color:green;color:green;}
+    .label.button.label-label-2:not(.no-hover):hover,.label.label-label-2.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
   >
     <span
-      className="label first selected"
-      id="label-first"
+      className="label label-label-1 selected"
+      id="label-1"
       title="first label"
     >
       <span
@@ -79,8 +79,8 @@ exports[`LabelPane not editable 1`] = `
       first
     </span>
     <span
-      className="label second"
-      id="label-second"
+      className="label label-label-2"
+      id="label-2"
       title="second label"
     >
       <span
@@ -101,19 +101,19 @@ exports[`LabelPane with selected labels 1`] = `
   <style
     type="text/css"
   >
-    .label.first.button:not(.selected){background-color:white;}
-    .label.first:not(.button):not(.selected){border-color:red;color:red;}
-    .label.button.first:not(.no-hover):hover,.label.first.selected{background-color:red;}
-    .label.second.button:not(.selected){background-color:white;}
-    .label.second:not(.button):not(.selected){border-color:green;color:green;}
-    .label.button.second:not(.no-hover):hover,.label.second.selected{background-color:green;}
+    .label.label-label-1.button:not(.selected){background-color:white;}
+    .label.label-label-1:not(.button):not(.selected){border-color:red;color:red;}
+    .label.button.label-label-1:not(.no-hover):hover,.label.label-label-1.selected{background-color:red;}
+    .label.label-label-2.button:not(.selected){background-color:white;}
+    .label.label-label-2:not(.button):not(.selected){border-color:green;color:green;}
+    .label.button.label-label-2:not(.no-hover):hover,.label.label-label-2.selected{background-color:green;}
   </style>
   <div
     className="label-selector-list"
   >
     <button
-      className="button label first selected"
-      id="label-first"
+      className="button label label-label-1 selected"
+      id="label-1"
       onClick={[Function]}
       title="first label"
       type="button"
@@ -126,8 +126,8 @@ exports[`LabelPane with selected labels 1`] = `
       first
     </button>
     <button
-      className="button label second"
-      id="label-second"
+      className="button label label-label-2"
+      id="label-2"
       onClick={[Function]}
       title="second label"
       type="button"

--- a/src/__test__/__snapshots__/label-pane.test.jsx.snap
+++ b/src/__test__/__snapshots__/label-pane.test.jsx.snap
@@ -94,6 +94,106 @@ exports[`LabelPane not editable 1`] = `
 </div>
 `;
 
+exports[`LabelPane sorts labels 1`] = `
+<div
+  className=""
+>
+  <style
+    type="text/css"
+  >
+    .label.label-id-0.button:not(.selected){background-color:white;}
+    .label.label-id-0:not(.button):not(.selected){border-color:undefined;color:undefined;}
+    .label.button.label-id-0:not(.no-hover):hover,.label.label-id-0.selected{background-color:undefined;}
+    .label.label-id-4.button:not(.selected){background-color:white;}
+    .label.label-id-4:not(.button):not(.selected){border-color:undefined;color:undefined;}
+    .label.button.label-id-4:not(.no-hover):hover,.label.label-id-4.selected{background-color:undefined;}
+    .label.label-id-3.button:not(.selected){background-color:white;}
+    .label.label-id-3:not(.button):not(.selected){border-color:undefined;color:undefined;}
+    .label.button.label-id-3:not(.no-hover):hover,.label.label-id-3.selected{background-color:undefined;}
+    .label.label-id-2.button:not(.selected){background-color:white;}
+    .label.label-id-2:not(.button):not(.selected){border-color:undefined;color:undefined;}
+    .label.button.label-id-2:not(.no-hover):hover,.label.label-id-2.selected{background-color:undefined;}
+    .label.label-id-1.button:not(.selected){background-color:white;}
+    .label.label-id-1:not(.button):not(.selected){border-color:undefined;color:undefined;}
+    .label.button.label-id-1:not(.no-hover):hover,.label.label-id-1.selected{background-color:undefined;}
+  </style>
+  <div
+    className="label-selector-list"
+  >
+    <button
+      className="button label label-id-0"
+      id="id-0"
+      onClick={[Function]}
+      title={undefined}
+      type="button"
+    >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
+      featured
+    </button>
+    <button
+      className="button label label-id-4"
+      id="id-4"
+      onClick={[Function]}
+      title={undefined}
+      type="button"
+    >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
+      a-label-3
+    </button>
+    <button
+      className="button label label-id-3"
+      id="id-3"
+      onClick={[Function]}
+      title={undefined}
+      type="button"
+    >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
+      a-label-4
+    </button>
+    <button
+      className="button label label-id-2"
+      id="id-2"
+      onClick={[Function]}
+      title={undefined}
+      type="button"
+    >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
+      a-label-1
+    </button>
+    <button
+      className="button label label-id-1"
+      id="id-1"
+      onClick={[Function]}
+      title={undefined}
+      type="button"
+    >
+      <span
+        className="ion-pricetag"
+      >
+         
+      </span>
+      a-label-2
+    </button>
+  </div>
+</div>
+`;
+
 exports[`LabelPane with selected labels 1`] = `
 <div
   className="css-class"

--- a/src/__test__/add-edit-page.test.jsx
+++ b/src/__test__/add-edit-page.test.jsx
@@ -35,6 +35,7 @@ describe('AddEditEventPage', () => {
     const wrapper = shallow(<AddEditEventPage
       eventData={event}
       match={{ params: { id: 1 } }}
+      possibleLabels={{}}
       setPageTitlePrefix={() => undefined}
       setSidebarMode={() => undefined}
       toggleSidebarCollapsed={() => undefined}

--- a/src/__test__/label-pane.test.jsx
+++ b/src/__test__/label-pane.test.jsx
@@ -4,8 +4,8 @@ import LabelPane from '../components/label-pane';
 
 describe('LabelPane', () => {
   const labels = {
-    first: { color: 'red', description: 'first label' },
-    second: { color: 'green', description: 'second label' },
+    first: { id: 'label-1', color: 'red', description: 'first label' },
+    second: { id: 'label-2', color: 'green', description: 'second label' },
   };
   test('matches snapshot', () => {
     const component = renderer.create(<LabelPane contentClass="css-class" possibleLabels={labels} />);

--- a/src/__test__/label-pane.test.jsx
+++ b/src/__test__/label-pane.test.jsx
@@ -4,8 +4,18 @@ import LabelPane from '../components/label-pane';
 
 describe('LabelPane', () => {
   const labels = {
-    first: { id: 'label-1', color: 'red', description: 'first label' },
-    second: { id: 'label-2', color: 'green', description: 'second label' },
+    first: {
+      name: 'first',
+      id: 'label-1',
+      color: 'red',
+      description: 'first label',
+    },
+    second: {
+      name: 'second',
+      id: 'label-2',
+      color: 'green',
+      description: 'second label',
+    },
   };
   test('matches snapshot', () => {
     const component = renderer.create(<LabelPane contentClass="css-class" possibleLabels={labels} />);
@@ -19,6 +29,23 @@ describe('LabelPane', () => {
   });
   test('not editable', () => {
     const component = renderer.create(<LabelPane contentClass="css-class" editable={false} possibleLabels={labels} selectedLabels={['first']} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test('sorts labels', () => {
+    const labels2 = {
+      0: { name: 'featured' },
+      1: { name: 'a-label-2' },
+      2: { name: 'a-label-1' },
+      3: { name: 'a-label-4', default: true },
+      4: { name: 'a-label-3', default: true },
+    };
+    // These should come out in order 'featured', 'a-label-3', 'a-label-4', 'a-label-1', a-label-2'.
+    // Initially verified from manual inspection of the snapshot.
+    Object.values(labels2).forEach((label, ix) => {
+      label.id = `id-${ix}`; // eslint-disable-line no-param-reassign
+    });
+    const component = renderer.create(<LabelPane possibleLabels={labels2} showUnselected />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -25,10 +25,10 @@ export default class LabelPane extends React.Component {
     const labelClicked = labelName => this.props.labelToggled(labelName);
 
     function renderLabel(name) {
-      const tooltip = labels[name].description;
+      const { description: tooltip, id } = labels[name];
       const selected = selectedLabels.includes(name);
-      const classes = `label ${name}${selected ? ' selected' : ''}`;
-      const id = `label-${name}`;
+      const cssId = `label-${id}`;
+      const classes = `label ${cssId}${selected ? ' selected' : ''}`;
       return editable ? (
         <button
           id={id}
@@ -49,7 +49,8 @@ export default class LabelPane extends React.Component {
       );
     }
     function getLabelCss(name) {
-      const { color } = labels[name];
+      const { color, id } = labels[name];
+      const cssId = `label-${id}`;
       // Joining the list of strings, and then again the caller, is less
       // efficient, but I found it clearer, and this code is not run much
       // and hasn't shown up as a hot spot.
@@ -57,10 +58,10 @@ export default class LabelPane extends React.Component {
       // Join w/ '\n', here and in caller, for more readable debugging and
       // snapshots.
       return [
-        `.label.${name}.button:not(.selected){background-color:white;}`,
-        `.label.${name}:not(.button):not(.selected){border-color:${color};color:${color};}`,
+        `.label.${cssId}.button:not(.selected){background-color:white;}`,
+        `.label.${cssId}:not(.button):not(.selected){border-color:${color};color:${color};}`,
         // hovered button, or selected
-        `.label.button.${name}:not(.no-hover):hover,.label.${name}.selected{background-color:${color};}`,
+        `.label.button.${cssId}:not(.no-hover):hover,.label.${cssId}.selected{background-color:${color};}`,
       ].join('\n');
     }
 

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -9,8 +9,6 @@ export default class LabelPane extends React.Component {
     if (props.refreshLabelsIfNeeded) props.refreshLabelsIfNeeded();
   }
 
-  labelClicked = labelName => this.props.labelToggled(labelName);
-
   render() {
     const {
       editable, possibleLabels: labels, selectedLabels, showUnselected,
@@ -20,34 +18,36 @@ export default class LabelPane extends React.Component {
     }
     const enableHoverStyle = !this.props.general.isMobile && this.props.editable;
     const noHoverClass = enableHoverStyle ? '' : 'no-hover ';
-    const labelElems = [];
-    Object.keys(labels).forEach((name) => {
+    let labelKeys = Object.keys(labels);
+    if (!showUnselected) {
+      labelKeys = Object.select(labelKeys, selectedLabels.includes);
+    }
+    const labelClicked = labelName => this.props.labelToggled(labelName);
+
+    function renderLabel(name) {
       const tooltip = labels[name].description;
       const selected = selectedLabels.includes(name);
-      if (selected || showUnselected) {
-        const classes = `label ${name}${selected ? ' selected' : ''}`;
-        const id = `label-${name}`;
-        if (editable) {
-          labelElems.push(<button
-            id={id}
-            key={name}
-            title={tooltip}
-            type="button"
-            className={`button ${noHoverClass}${classes}`}
-            onClick={() => this.labelClicked(name)}
-          >
-              <span className="ion-pricetag">&nbsp;</span>
-              {name}
-                          </button>);
-        } else {
-          labelElems.push(<span id={id} key={name} title={tooltip} className={classes}>
-            <span className="ion-pricetag">&nbsp;</span>
-            {name}
-                          </span>);
-        }
-      }
-    });
-
+      const classes = `label ${name}${selected ? ' selected' : ''}`;
+      const id = `label-${name}`;
+      return editable ? (
+        <button
+          id={id}
+          key={name}
+          title={tooltip}
+          type="button"
+          className={`button ${noHoverClass}${classes}`}
+          onClick={() => labelClicked(name)}
+        >
+          <span className="ion-pricetag">&nbsp;</span>
+          {name}
+        </button>
+      ) : (
+        <span id={id} key={name} title={tooltip} className={classes}>
+          <span className="ion-pricetag">&nbsp;</span>
+          {name}
+        </span>
+      );
+    }
     function getLabelCss(name) {
       const { color } = labels[name];
       // Joining the list of strings, and then again the caller, is less
@@ -66,8 +66,8 @@ export default class LabelPane extends React.Component {
 
     return (
       <div className={this.props.contentClass}>
-        <style type="text/css">{Object.keys(labels).map(getLabelCss).join('\n')}</style>
-        <div className="label-selector-list">{labelElems}</div>
+        <style type="text/css">{labelKeys.map(getLabelCss).join('\n')}</style>
+        <div className="label-selector-list">{labelKeys.map(renderLabel)}</div>
       </div>
     );
   }

--- a/src/components/label-pane.jsx
+++ b/src/components/label-pane.jsx
@@ -13,9 +13,11 @@ export default class LabelPane extends React.Component {
 
   render() {
     const {
-      editable, possibleLabels, selectedLabels, showUnselected,
+      editable, possibleLabels: labels, selectedLabels, showUnselected,
     } = this.props;
-    const labels = possibleLabels || [];
+    if (!labels) {
+      return <div className="loading" />;
+    }
     const enableHoverStyle = !this.props.general.isMobile && this.props.editable;
     const noHoverClass = enableHoverStyle ? '' : 'no-hover ';
     const labelElems = [];
@@ -73,11 +75,14 @@ export default class LabelPane extends React.Component {
 
 // Define React prop types for type checking during development
 LabelPane.propTypes = {
-  general: PropTypes.object,
+  general: PropTypes.shape({ isMobile: PropTypes.bool }),
   editable: PropTypes.bool,
   showUnselected: PropTypes.bool,
-  possibleLabels: PropTypes.object,
-  selectedLabels: PropTypes.array,
+  possibleLabels: PropTypes.objectOf(PropTypes.shape({
+    color: PropTypes.string,
+    description: PropTypes.string,
+  })),
+  selectedLabels: PropTypes.arrayOf(PropTypes.string),
   contentClass: PropTypes.string,
 };
 
@@ -85,6 +90,7 @@ LabelPane.propTypes = {
 LabelPane.defaultProps = {
   general: {},
   editable: true,
+  possibleLabels: {},
   selectedLabels: [],
   showUnselected: true,
   contentClass: '',


### PR DESCRIPTION
## Description

Sort labels. Currently “featured” goes first, then default labels, then non-defaults, with labels alphabetized within each section. This feels right for the sidebar 

This also fixes an issue where “Final Events” displayed funny in the Add/Edit Event view, because its name (with an unquoted space) was used as a CSS selector. Now the label id is used.

Also expected the Object and Array proptypes to specify their values.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [x] New code is covered by new or existing tests.
* [x] Changed code is covered by new or existing tests.