### PR TITLE
UX bugfixes: refresh on delete & load labels from URL

### DIFF
--- a/src/data/actions.js
+++ b/src/data/actions.js
@@ -411,6 +411,7 @@ export function eventDeletedSuccessfully(eventId) {
       action: 'success',
       label: `Event ${eventId} deleted successfully`,
     });
+    dispatch(refreshEventsForCurrentViewWindow());
     dispatch(push('/'));
   };
 }

--- a/src/pages/calendar/calendar-page.jsx
+++ b/src/pages/calendar/calendar-page.jsx
@@ -12,12 +12,8 @@ export default class CalendarPage extends React.Component {
 
     // Load the visible labels from the URL (if defined)
     const labelsStr = this.props.match.params.labels;
-    const labels = this.props.labels.labelList;
-    if (labels && labelsStr && labelsStr.length > 0) {
-      const labelsArr = labelsStr.split(',');
-      Object.keys(labels).forEach((labelName) => {
-        labels[labelName].selected = labelName in labelsArr;
-      });
+    if (labelsStr && labelsStr.length > 0) {
+      const labelsArr = labelsStr.split(',').sort();
       this.props.setVisibleLabels(labelsArr);
     }
 


### PR DESCRIPTION
## Description
Fixed:
* Event deletion not reflected on calendar until page refresh
* Labels not loaded from URL anymore

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.
