### PR TITLE
Fix the time display of all day (and non-all-day) events, and handle all_day property

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "markdownlint-cli": "^0.8.1",
+    "moment-timezone": "^0.5.16",
     "react-codemirror": "^1.0.0",
     "react-tag-input": "git+https://github.com/kylecombes/react-tags.git",
     "react-test-renderer": "^15.0.0",

--- a/src/__test__/__snapshots__/event_details-page.test.jsx.snap
+++ b/src/__test__/__snapshots__/event_details-page.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`EventDetailsPage multi-day all-day event 1`] = `
     <h1
       className="page-title"
     >
-      Title
+      Multi-day event from 5.07–5.08
     </h1>
     <div
       className="event-info-container"
@@ -75,7 +75,7 @@ exports[`EventDetailsPage regular event 1`] = `
     <h1
       className="page-title"
     >
-      Title
+      Event at 9-10AM 5.07
     </h1>
     <div
       className="event-info-container"
@@ -124,7 +124,7 @@ exports[`EventDetailsPage single-day all-day event 1`] = `
     <h1
       className="page-title"
     >
-      Title
+      All-day event on 5.07
     </h1>
     <div
       className="event-info-container"

--- a/src/__test__/__snapshots__/event_details-page.test.jsx.snap
+++ b/src/__test__/__snapshots__/event_details-page.test.jsx.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventDetailsPage loading 1`] = `
+<div
+  className="row expanded page-container"
+>
+  <div
+    className="row content-container"
+  >
+    <h1
+      className="page-title"
+    >
+      Loading...
+    </h1>
+  </div>
+</div>
+`;
+
+exports[`EventDetailsPage multi-day all-day event 1`] = `
+<div
+  className="row expanded page-container"
+>
+  <div
+    className="row content-container"
+  >
+    <h1
+      className="page-title"
+    >
+      Title
+    </h1>
+    <div
+      className="event-info-container"
+    >
+      <div
+        className="event-date-location-container"
+      >
+        <span
+          className="event-start"
+        >
+          Mon, May 7, 2018
+        </span>
+        <span>
+           to
+          <span
+            className="event-start"
+          >
+             Tue, May 8, 2018
+          </span>
+        </span>
+        <p
+          className="event-location"
+        >
+          Location
+        </p>
+      </div>
+      <div
+        className="description-container"
+      >
+        <p>
+          Description
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EventDetailsPage regular event 1`] = `
+<div
+  className="row expanded page-container"
+>
+  <div
+    className="row content-container"
+  >
+    <h1
+      className="page-title"
+    >
+      Title
+    </h1>
+    <div
+      className="event-info-container"
+    >
+      <div
+        className="event-date-location-container"
+      >
+        <span
+          className="event-start"
+        >
+          Mon, May 7, 2018 9:00 AM
+        </span>
+        <span>
+           to
+          <span
+            className="event-start"
+          >
+             10:00 AM
+          </span>
+        </span>
+        <p
+          className="event-location"
+        >
+          Location
+        </p>
+      </div>
+      <div
+        className="description-container"
+      >
+        <p>
+          Description
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EventDetailsPage single-day all-day event 1`] = `
+<div
+  className="row expanded page-container"
+>
+  <div
+    className="row content-container"
+  >
+    <h1
+      className="page-title"
+    >
+      Title
+    </h1>
+    <div
+      className="event-info-container"
+    >
+      <div
+        className="event-date-location-container"
+      >
+        <span
+          className="event-start"
+        >
+          Mon, May 7, 2018
+        </span>
+        <p
+          className="event-location"
+        >
+          Location
+        </p>
+      </div>
+      <div
+        className="description-container"
+      >
+        <p>
+          Description
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/__test__/encoding.test.jsx
+++ b/src/__test__/encoding.test.jsx
@@ -1,12 +1,14 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { decodeEvent, encodeEvent } from '../data/encoding';
 
 describe('decodeEvent', () => {
+  moment.tz.setDefault('EDT');
   test('decodes dates', () => {
     const event = decodeEvent({ start: '2018-05-07T09:00:00Z', end: '2018-05-07T10:00:00Z' });
-    expect(event.start).toBeInstanceOf(moment);
+    // expect(event.start).toBeInstanceOf(moment);
+    // expect(event.end).toBeInstanceOf(moment);
     expect(event.start.format()).toBe('2018-05-07T05:00:00-04:00');
-    expect(event.end).toBeInstanceOf(moment);
+    expect(event.end.format()).toBe('2018-05-07T06:00:00-04:00');
   });
   test('renames all_day property', () => {
     const event = decodeEvent({ all_day: true });
@@ -17,6 +19,7 @@ describe('decodeEvent', () => {
 });
 
 describe('encodeEvent', () => {
+  moment.tz.setDefault('EDT');
   test.skip('renames allDay', () => {
     // TODO: enable this, and remove the next two tests, once the decodeEvent no
     // longer has side effects.

--- a/src/__test__/encoding.test.jsx
+++ b/src/__test__/encoding.test.jsx
@@ -7,8 +7,8 @@ describe('decodeEvent', () => {
     const event = decodeEvent({ start: '2018-05-07T09:00:00Z', end: '2018-05-07T10:00:00Z' });
     // expect(event.start).toBeInstanceOf(moment);
     // expect(event.end).toBeInstanceOf(moment);
-    expect(event.start.format()).toBe('2018-05-07T05:00:00-04:00');
-    expect(event.end.format()).toBe('2018-05-07T06:00:00-04:00');
+    expect(event.start.utc().format()).toBe('2018-05-07T09:00:00Z');
+    expect(event.end.utc().format()).toBe('2018-05-07T10:00:00Z');
   });
   test('renames all_day property', () => {
     const event = decodeEvent({ all_day: true });

--- a/src/__test__/encoding.test.jsx
+++ b/src/__test__/encoding.test.jsx
@@ -1,0 +1,40 @@
+import moment from 'moment';
+import { decodeEvent, encodeEvent } from '../data/encoding';
+
+describe('decodeEvent', () => {
+  test('decodes dates', () => {
+    const event = decodeEvent({ start: '2018-05-07T09:00:00Z', end: '2018-05-07T10:00:00Z' });
+    expect(event.start).toBeInstanceOf(moment);
+    expect(event.start.format()).toBe('2018-05-07T05:00:00-04:00');
+    expect(event.end).toBeInstanceOf(moment);
+  });
+  test('renames all_day property', () => {
+    const event = decodeEvent({ all_day: true });
+    expect(event).not.toHaveProperty('all_day');
+    expect(event).toHaveProperty('allDay');
+    expect(event.allDay).toBe(true);
+  });
+});
+
+describe('encodeEvent', () => {
+  test.skip('renames allDay', () => {
+    // TODO: enable this, and remove the next two tests, once the decodeEvent no
+    // longer has side effects.
+    const event = encodeEvent({ allDay: true });
+    expect(event).toHaveProperty('all_day');
+    expect(event).not.toHaveProperty('allDay');
+    expect(event.all_day).toBe(true);
+  });
+  test('renames allDay on evidence of the new API', () => {
+    decodeEvent({ all_day: true }); // for effect
+    const event = encodeEvent({ allDay: true });
+    expect(event).toHaveProperty('all_day');
+    expect(event).not.toHaveProperty('allDay');
+  });
+  test('does not rename allDay on evidence of the old API', () => {
+    decodeEvent({ allDay: true }); // for effect
+    const event = encodeEvent({ allDay: true });
+    expect(event).not.toHaveProperty('all_day');
+    expect(event).toHaveProperty('allDay');
+  });
+});

--- a/src/__test__/event_details-page.test.jsx
+++ b/src/__test__/event_details-page.test.jsx
@@ -1,0 +1,51 @@
+import moment from 'moment';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import EventDetailsPage from '../pages/details/event-details-page';
+
+describe('EventDetailsPage', () => {
+  test('loading', () => {
+    const component = renderer.create(<EventDetailsPage eventData={null} setSidebarMode={() => undefined} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test('regular event', () => {
+    const event = {
+      title: 'Title',
+      location: 'Location',
+      description: 'Description',
+      start: moment('2018-05-07T09:00:00-04:00'),
+      end: moment('2018-05-07T10:00:00-04:00'),
+      allDay: false,
+    };
+    const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test('single-day all-day event', () => {
+    const event = {
+      title: 'Title',
+      location: 'Location',
+      description: 'Description',
+      start: moment('2018-05-07T00:00:00-04:00'),
+      end: moment('2018-05-07T23:59:59-04:00'),
+      allDay: true,
+    };
+    const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test('multi-day all-day event', () => {
+    const event = {
+      title: 'Title',
+      location: 'Location',
+      description: 'Description',
+      start: moment('2018-05-07T00:00:00-04:00'),
+      end: moment('2018-05-08T23:59:59-04:00'),
+      allDay: true,
+    };
+    const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/__test__/event_details-page.test.jsx
+++ b/src/__test__/event_details-page.test.jsx
@@ -1,9 +1,10 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import React from 'react';
 import renderer from 'react-test-renderer';
 import EventDetailsPage from '../pages/details/event-details-page';
 
 describe('EventDetailsPage', () => {
+  moment.tz.setDefault('EDT');
   test('loading', () => {
     const component = renderer.create(<EventDetailsPage eventData={null} setSidebarMode={() => undefined} />);
     const tree = component.toJSON();

--- a/src/__test__/event_details-page.test.jsx
+++ b/src/__test__/event_details-page.test.jsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import EventDetailsPage from '../pages/details/event-details-page';
 
 describe('EventDetailsPage', () => {
-  moment.tz.setDefault('EDT');
+  moment.tz.setDefault('EST');
   test('loading', () => {
     const component = renderer.create(<EventDetailsPage eventData={null} setSidebarMode={() => undefined} />);
     const tree = component.toJSON();
@@ -12,11 +12,11 @@ describe('EventDetailsPage', () => {
   });
   test('regular event', () => {
     const event = {
-      title: 'Title',
+      title: 'Event at 9-10AM 5.07',
       location: 'Location',
       description: 'Description',
-      start: moment('2018-05-07T09:00:00-04:00'),
-      end: moment('2018-05-07T10:00:00-04:00'),
+      start: moment('2018-05-07T09:00:00-05:00'),
+      end: moment('2018-05-07T10:00:00-05:00'),
       allDay: false,
     };
     const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);
@@ -25,11 +25,11 @@ describe('EventDetailsPage', () => {
   });
   test('single-day all-day event', () => {
     const event = {
-      title: 'Title',
+      title: 'All-day event on 5.07',
       location: 'Location',
       description: 'Description',
-      start: moment('2018-05-07T00:00:00-04:00'),
-      end: moment('2018-05-07T23:59:59-04:00'),
+      start: moment('2018-05-07T00:00:00-05:00'),
+      end: moment('2018-05-07T23:59:59-05:00'),
       allDay: true,
     };
     const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);
@@ -38,11 +38,11 @@ describe('EventDetailsPage', () => {
   });
   test('multi-day all-day event', () => {
     const event = {
-      title: 'Title',
+      title: 'Multi-day event from 5.07–5.08',
       location: 'Location',
       description: 'Description',
-      start: moment('2018-05-07T00:00:00-04:00'),
-      end: moment('2018-05-08T23:59:59-04:00'),
+      start: moment('2018-05-07T00:00:00-05:00'),
+      end: moment('2018-05-08T23:59:59-05:00'),
       allDay: true,
     };
     const component = renderer.create(<EventDetailsPage eventData={event} setSidebarMode={() => undefined} />);

--- a/src/data/encoding.js
+++ b/src/data/encoding.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import moment from 'moment';
+
+// Remember which API the server is speaking. This hackey (and won't work if the
+// user creates an event in an empty database), but only needs to get us through
+// an API transition and can then be removed.
+//
+// TODO: Remove this variable, and simplify its users, once olinlibrary/ABE#243
+// is on production and active developer branches.
+let useSnakeCaseProperties = true;
+
+const toLocalDate = date => moment.utc(date).local();
+
+const decodeDateTime = value => (moment.isMoment(value) ? value : toLocalDate(value));
+
+/**
+ *  Convert an event from the client-server API format to this app's internal format.
+ */
+export function decodeEvent(data) {
+  useSnakeCaseProperties = 'all_day' in data;
+  return _.chain(data)
+    .mapKeys((_value, key) => (key === 'all_day' ? 'allDay' : key))
+    .mapValues((value, key) => (key === 'start' || key === 'end' ? decodeDateTime(data[key]) : value))
+    .value();
+}
+
+/**
+ *  Convert an event from this app's internal format to the client-server API format.
+ */
+export function encodeEvent(event) {
+  return useSnakeCaseProperties ? _.mapKeys(event, (_value, key) => (key === 'allDay' ? 'all_day' : key)) : event;
+}

--- a/src/pages/details/event-details-page.jsx
+++ b/src/pages/details/event-details-page.jsx
@@ -23,36 +23,41 @@ export default class EventDetailsPage extends React.Component {
   }
 
   render() {
-    if (this.props.eventData) {
-      const oneDay = this.props.eventData.start.diff(this.props.eventData.end, 'days') === 0;
-      const timeFormat = this.props.eventData.allDay ? '' : ' h:mm A';
-      const startDateFormat = `ddd, MMM D, YYYY${timeFormat}`;
-      const endDateFormat = (oneDay) ? timeFormat : ` ddd, MMM D, YYYY${timeFormat}`;
-      const end = this.props.eventData.allDay && oneDay &&
-        <span> to<span className="event-start">{this.props.eventData.end.format(endDateFormat)}</span></span>;
-      const recurrence = this.props.eventData.recurrence &&
-        <PlainEnglishRecurrence recurrence={this.props.eventData.recurrence} start={this.props.eventData.start} />;
+    const { eventData: event } = this.props;
+    if (!event) {
       return (
         <div className="row expanded page-container">
           <div className="row content-container">
-            <h1 className="page-title">{this.props.eventData.title}</h1>
-            <div className="event-info-container">
-              <div className="event-date-location-container">
-                <span className="event-start">{this.props.eventData.start.format(startDateFormat)}</span>
-                {end}
-                {recurrence}
-                <p className="event-location">{this.props.eventData.location}</p>
-              </div>
-              <Markdown source={this.props.eventData.description} className="description-container" />
-            </div>
+            <h1 className="page-title">Loading...</h1>
           </div>
         </div>
       );
     }
+
+    const oneDay = event.start.diff(event.end, 'days') === 0;
+    const timeFormat = event.allDay ? '' : ' h:mm A';
+    const startDateFormat = `ddd, MMM D, YYYY${timeFormat}`;
+    const endDateFormat = oneDay ? timeFormat : ` ddd, MMM D, YYYY${timeFormat}`;
+    const end = !(event.allDay && oneDay) && (
+      <span>
+        &nbsp;to
+        <span className="event-start">{event.end.format(endDateFormat)}</span>
+      </span>
+    );
+    const recurrence = event.recurrence && <PlainEnglishRecurrence recurrence={event.recurrence} start={event.start} />;
     return (
       <div className="row expanded page-container">
         <div className="row content-container">
-          <h1 className="page-title">Loading...</h1>
+          <h1 className="page-title">{event.title}</h1>
+          <div className="event-info-container">
+            <div className="event-date-location-container">
+              <span className="event-start">{event.start.format(startDateFormat)}</span>
+              {end}
+              {recurrence}
+              <p className="event-location">{event.location}</p>
+            </div>
+            <Markdown source={event.description} className="description-container" />
+          </div>
         </div>
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,7 +5614,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
-moment-timezone@^0.5.14:
+moment-timezone@^0.5.14, moment-timezone@^0.5.16:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.16.tgz#661717d5f55b4d2c2e002262d726c83785192a5a"
   dependencies:


### PR DESCRIPTION
## Description
09dbd6f *Replace allDay -> all_day in server API*

Starts #214

This allows the client to work with old- and new-API servers. Once the client is deployed through to production, and then the API server is deployed through to production and on dev branches, then the API version detection can be backed out.

0e2a206 *Fixes #212 all-day events have end time, other events don't*

Verified by manual inspection of the snapshot file. Now that this is done, the test should prevent regressions.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [x] New code is covered by new or existing tests.
* [x] Changed code is covered by new or existing tests.