### PR TITLE
Re-apply changes to update UX for subscribing in Outlook or Google Ca…

### DIFF
--- a/src/pages/subscription/subscription.jsx
+++ b/src/pages/subscription/subscription.jsx
@@ -1,11 +1,11 @@
 // This component allows the user to import a calendar from an ICS feed
 
-import * as React from 'react';
 import axios from 'axios';
 import copy from 'copy-to-clipboard';
-import SidebarModes from '../../data/sidebar-modes';
+import * as React from 'react';
 import TagPane from '../../components/label-pane';
 import MenuIconButton from '../../components/menu-icon-button';
+import SidebarModes from '../../data/sidebar-modes';
 
 export default class SubscriptionEditorPage extends React.Component {
   constructor(props) {
@@ -18,7 +18,8 @@ export default class SubscriptionEditorPage extends React.Component {
       },
     };
 
-    axios.get(`${window.abe_url}/subscriptions/${this.getIdFromURL(props)}`)
+    axios
+      .get(`${window.abe_url}/subscriptions/${this.getIdFromURL(props)}`)
       .then(
         response => this.setState({ data: Object.assign({}, this.state.data, response.data) }),
         (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message),
@@ -54,14 +55,13 @@ export default class SubscriptionEditorPage extends React.Component {
   // };
 
   submitSubscription = () => {
-    axios.put(`${window.abe_url}/subscriptions/${this.state.data.id}`, this.state.data)
-      .then(
-        (response) => {
-          this.setState({ data: Object.assign({}, this.state.data, response.data) });
-          this.props.importSuccess(response, response.data);
-        },
-        (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message),
-      );
+    axios.put(`${window.abe_url}/subscriptions/${this.state.data.id}`, this.state.data).then(
+      (response) => {
+        this.setState({ data: Object.assign({}, this.state.data, response.data) });
+        this.props.importSuccess(response, response.data);
+      },
+      (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message),
+    );
   };
 
   copyToClipboard() {
@@ -91,7 +91,22 @@ export default class SubscriptionEditorPage extends React.Component {
           <br />
           <input type="submit" className="button submit" value="Submit" onClick={this.submitSubscription} />
           <br />
-          <input type="submit" className="button submit" value="Copy feed URL" onClick={this.copyToClipboard} />
+          <a
+            href={`webcal:${window.abe_url.split(':')[1]}${this.state.data.ics_url}`}
+            className="ics-copy-to-clipboard"
+          >
+            Import into Outlook
+          </a>
+
+          <a
+            href="https://github.com/olinlibrary/abe-web/wiki/Integrate-with-Your-Calendar#step-2-b-google-calendar"
+            className="ics-copy-to-clipboard"
+            onClick={() => {
+              this.copyToClipboard(this.state.data.ics_url);
+            }}
+          >
+            Import into Google Calendar
+          </a>
         </div>
       </div>
     );

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -1,11 +1,10 @@
 // The component provides information to the user about ICS feed generation. It also gives
 // them a button to click to generate an ICS feed.
 
-import React from 'react';
-import copy from 'copy-to-clipboard';
 import axios from 'axios';
+import copy from 'copy-to-clipboard';
+import React from 'react';
 import { OutboundLink } from 'react-ga';
-
 
 export default class GenerateICSPane extends React.Component {
   constructor(props) {
@@ -31,49 +30,28 @@ export default class GenerateICSPane extends React.Component {
 
     const labels = this.props.selectedLabels;
 
-    const temp_id = Math.random().toString(16).substring(2, 12)
-      + Math.random().toString(16).substring(2, 12)
-      + Math.random().toString(16).substring(2, 12);
-    const temp_url = `/subscriptions/${temp_id}/ics`;
-    this.copyToClipboard(temp_url);
+    const url = `${window.abe_url}/subscriptions/`;
 
-    const url = `${window.abe_url}/subscriptions/${temp_id}`;
-
-    axios.post(url, { labels })
-      .then(
-        (response) => {
-          this.setState({ data: Object.assign({}, this.state.data, response.data) });
-          if (response.data.ics_url !== temp_url) {
-            // The server has returned an ICS url that is different than
-            // the one we preemptively generated. This could happen if the format
-            // of the URL changes in some future version, or if the server objects
-            // to our generated ID for some reason and generates its own.
-            //
-            // This should never happen, but handling it here allows future changes
-            // to URL format to be pushed separately to the backend and frontend
-            // repos, with only slight user inconvenience during the transition.
-
-            this.copyToClipboard(this.state.data.ics_url);
-            console.warn(`Double copy needed because returned ics_url "${
-              response.data.ics_url}" did not match expected "${temp_url}"`);
-          }
-          alert('Link copied to clipboard');
-        },
-        (_jqXHR, _textStatus, _errorThrown) =>
-          alert('Failed to get Feed URL'),
-      );
+    axios.post(url, { labels }).then(
+      (response) => {
+        this.setState({ data: Object.assign({}, this.state.data, response.data) });
+      },
+      (_jqXHR, _textStatus, _errorThrown) => alert('Failed to get Feed URL'),
+    );
   }
 
   copyToClipboard(url) {
     copy(window.abe_url + url);
 
     this.props.icsUrlCopiedToClipboard(url);
+    alert('Feed URL copied to clipboard');
   }
 
   render() {
     return (
       <div>
-        <span className="sidebar-item-info">Use an ICS feed to add events with the selected tags to your own calendar (
+        <span className="sidebar-item-info">
+          Use an ICS feed to add events with the selected tags to your own calendar (
           <OutboundLink
             eventLabel="GitHub Wiki: Integrate with Your Calendar"
             to="https://github.com/olinlibrary/abe-web/wiki/Integrate-with-Your-Calendar"
@@ -81,18 +59,43 @@ export default class GenerateICSPane extends React.Component {
             title="Instructions for adding an ICS feed"
             target="_blank"
           >
-                instructions
+            instructions
           </OutboundLink>).
         </span>
         {/* <a className="ics-copy-to-clipboard" title="Copy feed URL" alt="Copy feed URL"
          onClick={this.getFeedUrl}>Copy link to clipboard</a> */}
-        <br /><br />
-        <input type="submit" className="button submit" value="Copy feed URL" onClick={this.getFeedUrl} />
+        <br />
+        <br />
+        <input type="submit" className="button submit" value="Generate event feed" onClick={this.getFeedUrl} />
 
-        {this.state.data.id.length > 0 &&
-        <a href={`/subscription/${this.state.data.id}`} className="ics-copy-to-clipboard" title="Edit feed preferences">
-          Edit feed preferences
-        </a>}
+        {this.state.data.id.length > 0 && (
+          <div>
+            <a
+              href={`/subscription/${this.state.data.id}`}
+              className="ics-copy-to-clipboard"
+              title="Edit feed preferences"
+            >
+              Edit feed preferences
+            </a>
+
+            <a
+              href={`webcal:${window.abe_url.split(':')[1]}${this.state.data.ics_url}`}
+              className="ics-copy-to-clipboard"
+            >
+              Import into Outlook
+            </a>
+
+            <a
+              href="https://github.com/olinlibrary/abe-web/wiki/Integrate-with-Your-Calendar#step-2-b-google-calendar"
+              className="ics-copy-to-clipboard"
+              onClick={() => {
+                this.copyToClipboard(this.state.data.ics_url);
+              }}
+            >
+              Import into Google Calendar
+            </a>
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Commit #05e04a3 “Fix Airbnb lint error” wiped out commit #f69b9a2 “Update UX for subscribing in Outlook or Google Calendar”.

This fix re-applies #05e04a3 `git co 05e04a3^ src/sidebar/generate-ics-pane.jsx src/pages/subscription/subscription.jsx`, an re-applying the eslint fixes.

## Required
Changes must conform to these requirements:
* [x] `yarn test` passes.  All new and existing tests pass.
* [x] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.
